### PR TITLE
Add TransformOps to HCL Dialect

### DIFF
--- a/include/hcl/Dialect/CMakeLists.txt
+++ b/include/hcl/Dialect/CMakeLists.txt
@@ -23,3 +23,5 @@ add_public_tablegen_target(MLIRHeteroCLEnumsIncGen)
 
 add_mlir_doc(HeteroCLDialect HeteroCLDialect HeteroCL/ -gen-dialect-doc)
 add_mlir_doc(HeteroCLOps HeteroCLOps HeteroCL/ -gen-op-doc)
+
+add_subdirectory(TransformOps)

--- a/include/hcl/Dialect/TransformOps/CMakeLists.txt
+++ b/include/hcl/Dialect/TransformOps/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(LLVM_TARGET_DEFINITIONS HCLTransformOps.td)
+mlir_tablegen(HCLTransformOps.h.inc -gen-op-decls)
+mlir_tablegen(HCLTransformOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRHCLTransformOpsIncGen)

--- a/include/hcl/Dialect/TransformOps/HCLTransformOps.h
+++ b/include/hcl/Dialect/TransformOps/HCLTransformOps.h
@@ -1,0 +1,37 @@
+//===- HCLTransformOps.h - HCL transformation ops ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_TRANSFORMOPS_HCLTRANSFORMOPS_H
+#define MLIR_DIALECT_TRANSFORMOPS_HCLTRANSFORMOPS_H
+
+#include "mlir/Dialect/PDL/IR/PDLTypes.h"
+#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+
+namespace mlir {
+namespace func {
+class FuncOp;
+} // namespace func
+namespace hcl {
+class ForOp;
+} // namespace hcl
+} // namespace mlir
+
+#define GET_OP_CLASSES
+#include "hcl/Dialect/TransformOps/HCLTransformOps.h.inc"
+
+namespace mlir {
+class DialectRegistry;
+
+namespace hcl {
+void registerTransformDialectExtension(DialectRegistry &registry);
+} // namespace hcl
+} // namespace mlir
+
+#endif // MLIR_DIALECT_TRANSFORMOPS_HCLTRANSFORMOPS_H

--- a/include/hcl/Dialect/TransformOps/HCLTransformOps.td
+++ b/include/hcl/Dialect/TransformOps/HCLTransformOps.td
@@ -56,7 +56,10 @@ def HCLLoopUnrollOp : Op<Transform_Dialect, "hcl.loop_unroll",
   let assemblyFormat = "$target attr-dict";
 
   let extraClassDeclaration = [{
-    ::mlir::LogicalResult applyToOne(::mlir::AffineForOp loop);
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::AffineForOp target, 
+        ::llvm::SmallVector<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
   }];
 }
 

--- a/include/hcl/Dialect/TransformOps/HCLTransformOps.td
+++ b/include/hcl/Dialect/TransformOps/HCLTransformOps.td
@@ -16,7 +16,7 @@ include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
-def HCLGetParentLoopOp : Op<Transform_Dialect, "hcl.get_parent_loop",
+def HCLParentLoopOp : Op<Transform_Dialect, "hcl.parent_loop",
     [NavigationTransformOpTrait, MemoryEffectsOpInterface,
      DeclareOpInterfaceMethods<TransformOpInterface>]> {
   let summary = "Gets a handle to the parent 'for' loop of the given operation";

--- a/include/hcl/Dialect/TransformOps/HCLTransformOps.td
+++ b/include/hcl/Dialect/TransformOps/HCLTransformOps.td
@@ -1,0 +1,63 @@
+//===- HCLTransformOps.td - HCL (loop) transformation ops --*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HCL_TRANSFORM_OPS
+#define HCL_TRANSFORM_OPS
+
+include "mlir/Dialect/Transform/IR/TransformDialect.td"
+include "mlir/Dialect/Transform/IR/TransformEffects.td"
+include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
+include "mlir/Dialect/PDL/IR/PDLTypes.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/OpBase.td"
+
+def HCLGetParentLoopOp : Op<Transform_Dialect, "hcl.get_parent_loop",
+    [NavigationTransformOpTrait, MemoryEffectsOpInterface,
+     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let summary = "Gets a handle to the parent 'for' loop of the given operation";
+  let description = [{
+    Produces a handle to the n-th (default 1) parent `affine.for` loop for each
+    Payload IR operation associated with the operand. Fails if such a loop
+    cannot be found. The list of operations associated with the handle contains
+    parent operations in the same order as the list associated with the operand,
+    except for operations that are parents to more than one input which are only
+    present once.
+  }];
+
+  let arguments =
+    (ins PDL_Operation:$target,
+         DefaultValuedAttr<Confined<I64Attr, [IntPositive]>,
+                           "1">:$num_loops);
+  let results = (outs PDL_Operation:$parent);
+
+  let assemblyFormat = "$target attr-dict";
+}
+
+def HCLLoopUnrollOp : Op<Transform_Dialect, "hcl.loop_unroll",
+    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+     TransformOpInterface, TransformEachOpTrait]> {
+  let summary = "Unrolls the given loop with the given unroll factor";
+  let description = [{
+     Unrolls each loop associated with the given handle to have up to the given
+     number of loop body copies per iteration. If the unroll factor is larger
+     than the loop trip count, the latter is used as the unroll factor instead.
+     Does not produce a new handle as the operation may result in the loop being
+     removed after a full unrolling.
+  }];
+
+  let arguments = (ins PDL_Operation:$target,
+                       Confined<I64Attr, [IntPositive]>:$factor);
+
+  let assemblyFormat = "$target attr-dict";
+
+  let extraClassDeclaration = [{
+    ::mlir::LogicalResult applyToOne(::mlir::AffineForOp loop);
+  }];
+}
+
+#endif // HCL_TRANSFORM_OPS

--- a/include/hcl/Dialect/TransformOps/HCLTransformOps.td
+++ b/include/hcl/Dialect/TransformOps/HCLTransformOps.td
@@ -29,29 +29,73 @@ def HCLGetParentLoopOp : Op<Transform_Dialect, "hcl.get_parent_loop",
     present once.
   }];
 
-  let arguments =
-    (ins PDL_Operation:$target,
-         DefaultValuedAttr<Confined<I64Attr, [IntPositive]>,
-                           "1">:$num_loops);
+  let arguments = (ins PDL_Operation:$target, DefaultValuedAttr<
+                         Confined<I64Attr, [IntPositive]>, "1">:$num_loops);
   let results = (outs PDL_Operation:$parent);
 
   let assemblyFormat = "$target attr-dict";
 }
 
-def HCLLoopUnrollOp : Op<Transform_Dialect, "hcl.loop_unroll",
+def HCLUnrollOp : Op<Transform_Dialect, "hcl.unroll",
     [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
      TransformOpInterface, TransformEachOpTrait]> {
   let summary = "Unrolls the given loop with the given unroll factor";
   let description = [{
-     Unrolls each loop associated with the given handle to have up to the given
-     number of loop body copies per iteration. If the unroll factor is larger
-     than the loop trip count, the latter is used as the unroll factor instead.
-     Does not produce a new handle as the operation may result in the loop being
-     removed after a full unrolling.
+    Unrolls each loop associated with the given handle to have up to the given
+    number of loop body copies per iteration. If the unroll factor is larger
+    than the loop trip count, the latter is used as the unroll factor instead.
+    Does not produce a new handle as the operation may result in the loop being
+    removed after a full unrolling.
   }];
 
   let arguments = (ins PDL_Operation:$target,
                        Confined<I64Attr, [IntPositive]>:$factor);
+
+  let assemblyFormat = "$target attr-dict";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::AffineForOp target, 
+        ::llvm::SmallVector<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
+def HCLSplitOp : Op<Transform_Dialect, "hcl.split",
+    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+     TransformOpInterface, TransformEachOpTrait]> {
+  let summary = "Split the given loop with the given split factor";
+  let description = [{
+    Split each loop associated with the given handle to two loops. Produce two
+    handles cooresponding to the two loops generated.
+  }];
+
+  let arguments = (ins PDL_Operation:$target,
+                       Confined<I64Attr, [IntPositive]>:$factor);
+  let results = (outs PDL_Operation:$outer, PDL_Operation:$inner);
+
+  let assemblyFormat = "$target attr-dict";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::AffineForOp target, 
+        ::llvm::SmallVector<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
+def HCLPipelineOp : Op<Transform_Dialect, "hcl.pipeline",
+    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+     TransformOpInterface, TransformEachOpTrait]> {
+  let summary = "Pipeline the given loop with the given initial interval";
+  let description = [{
+    Pipeline each loop associated with the given handle. Produce the pipelined
+    loop.
+  }];
+
+  let arguments = (ins PDL_Operation:$target,
+                       Confined<I64Attr, [IntPositive]>:$initialInterval);
+  let results = (outs PDL_Operation:$result);
 
   let assemblyFormat = "$target attr-dict";
 

--- a/include/hcl/Transforms/Passes.h
+++ b/include/hcl/Transforms/Passes.h
@@ -21,6 +21,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createLowerCompositeTypePass();
 std::unique_ptr<OperationPass<ModuleOp>> createLowerBitOpsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createLegalizeCastPass();
 std::unique_ptr<OperationPass<ModuleOp>> createRemoveStrideMapPass();
+std::unique_ptr<OperationPass<ModuleOp>> createTransformInterpreterPass();
 
 bool applyLoopTransformation(ModuleOp &f);
 

--- a/include/hcl/Transforms/Passes.td
+++ b/include/hcl/Transforms/Passes.td
@@ -52,4 +52,9 @@ def RemoveStrideMap : Pass<"remove-stride-map", "ModuleOp"> {
   let constructor = "mlir::hcl::createRemoveStrideMapPass()";
 }
 
+def TransformInterpreter : Pass<"transform-interpreter", "ModuleOp"> {
+  let summary = "Rewrite the IR by interpreting transform ops";
+  let constructor = "mlir::hcl::createTransformInterpreterPass()";
+}
+
 #endif // HCL_MLIR_PASSES

--- a/lib/Bindings/Python/HCLModule.cpp
+++ b/lib/Bindings/Python/HCLModule.cpp
@@ -172,9 +172,12 @@ PYBIND11_MODULE(_hcl, m) {
     transform::TransformState state(
         module.getBodyRegion(), module,
         transform::TransformOptions().enableExpensiveChecks());
-    for (auto op : module.getBody()->getOps<transform::TransformOpInterface>())
+    for (auto op : llvm::make_early_inc_range(
+             module.getBody()->getOps<transform::TransformOpInterface>())) {
       if (failed(state.applyTransform(op).checkAndReport()))
         throw py::value_error("failed to apply the transform");
+      op.erase();
+    }
   });
 
   // Declare customized types and attributes

--- a/lib/Bindings/Python/HCLModule.cpp
+++ b/lib/Bindings/Python/HCLModule.cpp
@@ -15,11 +15,13 @@
 #include "hcl-c/Translation/EmitVivadoHLS.h"
 #include "hcl/Conversion/HCLToLLVM.h"
 #include "hcl/Dialect/HeteroCLDialect.h"
+#include "hcl/Dialect/TransformOps/HCLTransformOps.h"
 #include "hcl/Transforms/Passes.h"
 #include "mlir-c/Bindings/Python/Interop.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/Dialect/Affine/Analysis/LoopAnalysis.h"
+#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
 
 #include "llvm-c/ErrorHandling.h"
 #include "llvm/Support/Signals.h"
@@ -156,10 +158,24 @@ PYBIND11_MODULE(_hcl, m) {
       "register_dialect",
       [](MlirContext context) {
         MlirDialectHandle hcl = mlirGetDialectHandle__hcl__();
+        mlir::DialectRegistry registry;
+        mlir::hcl::registerTransformDialectExtension(registry);
+        unwrap(context)->appendDialectRegistry(registry);
         mlirDialectHandleRegisterDialect(hcl, context);
         mlirDialectHandleLoadDialect(hcl, context);
       },
       py::arg("context") = py::none());
+
+  // Apply transform to a design.
+  hcl_m.def("apply_transform", [](MlirModule &mlir_mod) {
+    ModuleOp module = unwrap(mlir_mod);
+    transform::TransformState state(
+        module.getBodyRegion(), module,
+        transform::TransformOptions().enableExpensiveChecks());
+    for (auto op : module.getBody()->getOps<transform::TransformOpInterface>())
+      if (failed(state.applyTransform(op).checkAndReport()))
+        throw py::value_error("failed to apply the transform");
+  });
 
   // Declare customized types and attributes
   populateHCLIRTypes(hcl_m);

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -14,6 +14,7 @@ add_mlir_public_c_api_library(MLIRHCLCAPI
   MLIRCAPIIR
   MLIRSupport
   MLIRHeteroCL
+  MLIRHCLTransformOps
   MLIRHCLPasses
   MLIRHCLConversion
   )

--- a/lib/CAPI/Dialect/Registration.cpp
+++ b/lib/CAPI/Dialect/Registration.cpp
@@ -25,7 +25,8 @@ void hclMlirRegisterAllDialects(MlirContext context) {
   registry.insert<mlir::hcl::HeteroCLDialect, mlir::func::FuncDialect,
                   mlir::arith::ArithmeticDialect, mlir::tensor::TensorDialect,
                   mlir::AffineDialect, mlir::math::MathDialect,
-                  mlir::memref::MemRefDialect, mlir::linalg::LinalgDialect>();
+                  mlir::memref::MemRefDialect, mlir::pdl::PDLDialect,
+                  mlir::transform::TransformDialect>();
   unwrap(context)->appendDialectRegistry(registry);
   unwrap(context)->loadAllAvailableDialects();
 }

--- a/lib/CAPI/Dialect/Registration.cpp
+++ b/lib/CAPI/Dialect/Registration.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Transforms/Passes.h"
 
 #include "hcl/Dialect/HeteroCLDialect.h"
+#include "hcl/Dialect/TransformOps/HCLTransformOps.h"
 #include "mlir/InitAllDialects.h"
 
 void hclMlirRegisterAllDialects(MlirContext context) {
@@ -27,6 +28,7 @@ void hclMlirRegisterAllDialects(MlirContext context) {
                   mlir::AffineDialect, mlir::math::MathDialect,
                   mlir::memref::MemRefDialect, mlir::pdl::PDLDialect,
                   mlir::transform::TransformDialect>();
+  mlir::hcl::registerTransformDialectExtension(registry);
   unwrap(context)->appendDialectRegistry(registry);
   unwrap(context)->loadAllAvailableDialects();
 }

--- a/lib/Dialect/CMakeLists.txt
+++ b/lib/Dialect/CMakeLists.txt
@@ -14,3 +14,5 @@ add_mlir_dialect_library(MLIRHeteroCL
 	LINK_LIBS PUBLIC
 	MLIRIR
 	)
+
+add_subdirectory(TransformOps)

--- a/lib/Dialect/TransformOps/CMakeLists.txt
+++ b/lib/Dialect/TransformOps/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_mlir_dialect_library(MLIRHCLTransformOps
+  HCLTransformOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/hcl/Dialect/TransformOps
+
+  DEPENDS
+  MLIRHCLTransformOpsIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRAffineDialect
+  MLIRFuncDialect
+  MLIRIR
+  MLIRPDLDialect
+  MLIRSCFDialect
+  MLIRSCFTransforms
+  MLIRSCFUtils
+  MLIRTransformDialect
+  MLIRVectorDialect
+)

--- a/lib/Dialect/TransformOps/HCLTransformOps.cpp
+++ b/lib/Dialect/TransformOps/HCLTransformOps.cpp
@@ -1,0 +1,91 @@
+//===- HCLTransformOps.cpp - Implementation of SCF transformation ops -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hcl/Dialect/TransformOps/HCLTransformOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/LoopUtils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+
+using namespace mlir;
+
+namespace {
+/// A simple pattern rewriter that implements no special logic.
+class SimpleRewriter : public PatternRewriter {
+public:
+  SimpleRewriter(MLIRContext *context) : PatternRewriter(context) {}
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// HCLGetParentLoopOp
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+transform::HCLGetParentLoopOp::apply(transform::TransformResults &results,
+                                     transform::TransformState &state) {
+  SetVector<Operation *> parents;
+  for (Operation *target : state.getPayloadOps(getTarget())) {
+    AffineForOp loop;
+    Operation *current = target;
+    for (unsigned i = 0, e = getNumLoops(); i < e; ++i) {
+      loop = current->getParentOfType<AffineForOp>();
+      if (!loop) {
+        DiagnosedSilenceableFailure diag = emitSilenceableError()
+                                           << "could not find an '"
+                                           << AffineForOp::getOperationName()
+                                           << "' parent";
+        diag.attachNote(target->getLoc()) << "target op";
+        return diag;
+      }
+      current = loop;
+    }
+    parents.insert(loop);
+  }
+  results.set(getResult().cast<OpResult>(), parents.getArrayRef());
+  return DiagnosedSilenceableFailure::success();
+}
+
+//===----------------------------------------------------------------------===//
+// HCLLoopUnrollOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult transform::HCLLoopUnrollOp::applyToOne(AffineForOp loop) {
+  if (failed(loopUnrollByFactor(loop, getFactor())))
+    return reportUnknownTransformError(loop);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Transform op registration
+//===----------------------------------------------------------------------===//
+
+namespace {
+class HCLTransformDialectExtension
+    : public transform::TransformDialectExtension<
+          HCLTransformDialectExtension> {
+public:
+  HCLTransformDialectExtension() {
+    declareDependentDialect<AffineDialect>();
+    declareDependentDialect<func::FuncDialect>();
+    registerTransformOps<
+#define GET_OP_LIST
+#include "hcl/Dialect/TransformOps/HCLTransformOps.cpp.inc"
+        >();
+  }
+};
+} // namespace
+
+#define GET_OP_CLASSES
+#include "hcl/Dialect/TransformOps/HCLTransformOps.cpp.inc"
+
+void mlir::hcl::registerTransformDialectExtension(DialectRegistry &registry) {
+  registry.addExtensions<HCLTransformDialectExtension>();
+}

--- a/lib/Dialect/TransformOps/HCLTransformOps.cpp
+++ b/lib/Dialect/TransformOps/HCLTransformOps.cpp
@@ -57,10 +57,16 @@ transform::HCLGetParentLoopOp::apply(transform::TransformResults &results,
 // HCLLoopUnrollOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult transform::HCLLoopUnrollOp::applyToOne(AffineForOp loop) {
-  if (failed(loopUnrollByFactor(loop, getFactor())))
-    return reportUnknownTransformError(loop);
-  return success();
+DiagnosedSilenceableFailure
+transform::HCLLoopUnrollOp::applyToOne(AffineForOp target,
+                                       SmallVector<Operation *> &results,
+                                       transform::TransformState &state) {
+  if (failed(loopUnrollByFactor(target, getFactor()))) {
+    Diagnostic diag(target->getLoc(), DiagnosticSeverity::Note);
+    diag << "op failed to unroll";
+    return DiagnosedSilenceableFailure::silenceableFailure(std::move(diag));
+  }
+  return DiagnosedSilenceableFailure(success());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TransformOps/HCLTransformOps.cpp
+++ b/lib/Dialect/TransformOps/HCLTransformOps.cpp
@@ -25,12 +25,12 @@ public:
 } // namespace
 
 //===----------------------------------------------------------------------===//
-// HCLGetParentLoopOp
+// HCLParentLoopOp
 //===----------------------------------------------------------------------===//
 
 DiagnosedSilenceableFailure
-transform::HCLGetParentLoopOp::apply(transform::TransformResults &results,
-                                     transform::TransformState &state) {
+transform::HCLParentLoopOp::apply(transform::TransformResults &results,
+                                  transform::TransformState &state) {
   SetVector<Operation *> parents;
   for (Operation *target : state.getPayloadOps(getTarget())) {
     AffineForOp loop;

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_library(MLIRHCLPasses
     Passes.cpp
     LegalizeCast.cpp
     RemoveStrideMap.cpp
+    TransformInterpreter.cpp
 
     ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/hcl

--- a/lib/Transforms/TransformInterpreter.cpp
+++ b/lib/Transforms/TransformInterpreter.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2021-2022 The hcl Authors.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "hcl/Transforms/Passes.h"
+#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
+
+using namespace mlir;
+using namespace hcl;
+
+namespace {
+struct TransformInterpreter
+    : public hcl::TransformInterpreterBase<TransformInterpreter> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void TransformInterpreter::runOnOperation() {
+  ModuleOp module = getOperation();
+  transform::TransformState state(
+      module.getBodyRegion(), module,
+      transform::TransformOptions().enableExpensiveChecks());
+  for (auto op : module.getBody()->getOps<transform::TransformOpInterface>()) {
+    if (failed(state.applyTransform(op).checkAndReport()))
+      return signalPassFailure();
+  }
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> hcl::createTransformInterpreterPass() {
+  return std::make_unique<TransformInterpreter>();
+}

--- a/tools/hcl-opt/CMakeLists.txt
+++ b/tools/hcl-opt/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBS
         MLIRIR
         MLIROptLib
         MLIRHeteroCL
+        MLIRHCLTransformOps
         MLIRHCLConversion
         MLIRHCLPasses
         )

--- a/tools/hcl-opt/hcl-opt.cpp
+++ b/tools/hcl-opt/hcl-opt.cpp
@@ -28,6 +28,7 @@
 #include "llvm/Support/ToolOutputFile.h"
 
 #include "hcl/Dialect/HeteroCLDialect.h"
+#include "hcl/Dialect/TransformOps/HCLTransformOps.h"
 
 #include "hcl/Conversion/HCLToLLVM.h"
 #include "hcl/Transforms/Passes.h"
@@ -160,6 +161,7 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
   mlir::registerAllDialects(registry);
   registry.insert<mlir::hcl::HeteroCLDialect>();
+  mlir::hcl::registerTransformDialectExtension(registry);
 
   mlir::MLIRContext context;
   context.appendDialectRegistry(registry);

--- a/tools/hcl-opt/hcl-opt.cpp
+++ b/tools/hcl-opt/hcl-opt.cpp
@@ -116,6 +116,11 @@ static llvm::cl::opt<bool> moveReturnToInput(
     llvm::cl::desc("Move return values to input argument list"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool>
+    applyTransform("apply-transform",
+                   llvm::cl::desc("Apply pattern-based transformations"),
+                   llvm::cl::init(false));
+
 int loadMLIR(mlir::MLIRContext &context,
              mlir::OwningOpRef<mlir::ModuleOp> &module) {
   module = parseSourceFile<mlir::ModuleOp>(inputFilename, &context);
@@ -236,6 +241,9 @@ int main(int argc, char **argv) {
     // Generic common sub expression elimination.
     // pm.addPass(mlir::createCSEPass());
   }
+
+  if (applyTransform)
+    pm.addPass(mlir::hcl::createTransformInterpreterPass());
 
   if (runJiT || lowerToLLVM) {
     if (!removeStrideMap) {


### PR DESCRIPTION
For now, two prototyping TransformOps, HCLGetParentLoopOp and HCLLoopUnrollOp, are extended to the Transform dialect. More operations, for example, SplitOp, will be added in the subsequent PRs. Meanwhile, a TransformInterpreter pass is added for testing purpose. 