### PR TITLE
[LLVM][FixedToInt] Fix #175 call op result type mismatch

### DIFF
--- a/lib/Conversion/FixedPointToInteger.cpp
+++ b/lib/Conversion/FixedPointToInteger.cpp
@@ -51,7 +51,6 @@ Value castIntegerWidth(MLIRContext *ctx, OpBuilder &builder, Location loc,
   return result;
 }
 
-// TODO(Niansong): function calls also need to be handled
 
 /* Update the function signature and
  * Because we need to interact with numpy, which only supports up

--- a/lib/Conversion/FixedPointToInteger.cpp
+++ b/lib/Conversion/FixedPointToInteger.cpp
@@ -985,6 +985,10 @@ void lowerIntToFixed(IntToFixedOp &op) {
   op->replaceAllUsesWith(lshifted);
 }
 
+void updateCallOp(func::CallOp &op) {
+  
+}
+
 // src and dst is guaranteed to be of different fixed types.
 // src: src_width, src_frac
 // dst: dst_width, dst_frac
@@ -1144,6 +1148,8 @@ void visitOperation(Operation &op) {
   } else if (auto new_op = dyn_cast<scf::IfOp>(op)) {
     // llvm::outs() << "IfOp\n";
     updateSCFIfOp(new_op);
+  } else if (auto new_op = dyn_cast<func::CallOp>(op)) {
+    updateCallOp(new_op);
   }
 
   for (auto &region : op.getRegions()) {

--- a/lib/Conversion/FixedPointToInteger.cpp
+++ b/lib/Conversion/FixedPointToInteger.cpp
@@ -63,9 +63,8 @@ FunctionType updateFunctionSignature(func::FuncOp &funcOp) {
   FunctionType functionType = funcOp.getFunctionType();
   SmallVector<Type, 4> result_types =
       llvm::to_vector<4>(functionType.getResults());
-  SmallVector<Type, 8> arg_types;
-  for (const auto &argEn : llvm::enumerate(funcOp.getArguments()))
-    arg_types.push_back(argEn.value().getType());
+  SmallVector<Type, 8> arg_types = 
+      llvm::to_vector<8>(functionType.getInputs());
 
   SmallVector<Type, 4> new_result_types;
   SmallVector<Type, 8> new_arg_types;

--- a/test/Transforms/datatype/fti_funcsig.mlir
+++ b/test/Transforms/datatype/fti_funcsig.mlir
@@ -1,0 +1,45 @@
+// RUN: hcl-opt %s --fixed-to-integer | FileCheck %s
+
+module {
+  func.func private @conv1(memref<1x1x28x28xf32>, memref<6x1x5x5xf32>) -> memref<1x6x28x28xi8>
+  func.func private @relu(memref<1x6x28x28xi8>) -> memref<1x6x28x28xi8>
+  func.func private @pool(memref<1x6x28x28xi8>) -> memref<1x6x14x14xi8>
+  func.func private @conv2(memref<1x6x14x14xi8>, memref<16x6x5x5xf32>) -> memref<1x16x10x10xi8>
+  func.func private @relu_1(memref<1x16x10x10xi8>) -> memref<1x16x10x10xi8>
+  func.func private @pool_1(memref<1x16x10x10xi8>) -> memref<1x16x5x5xi8>
+  func.func private @flatten(memref<1x16x5x5xi8>) -> memref<1x400xi8>
+  func.func private @fc1(memref<1x400xi8>, memref<120x400xf32>, memref<1x120xf32>) -> memref<1x120x!hcl.Fixed<8, 4>>
+  func.func private @relu_2(memref<1x120x!hcl.Fixed<8, 4>>) -> memref<1x120x!hcl.Fixed<8, 4>>
+  func.func private @fc2(memref<1x120x!hcl.Fixed<8, 4>>, memref<84x120xf32>, memref<1x84xf32>) -> memref<1x84x!hcl.Fixed<8, 4>>
+  func.func private @relu_3(memref<1x84x!hcl.Fixed<8, 4>>) -> memref<1x84x!hcl.Fixed<8, 4>>
+  func.func private @fc3(memref<1x84x!hcl.Fixed<8, 4>>, memref<10x84xf32>, memref<1x10xf32>) -> memref<1x10xf32>
+  func.func @main() {
+    %0 = memref.alloc() : memref<1x1x28x28xf32>
+    %1 = memref.alloc() : memref<6x1x5x5xf32>
+    %2 = memref.alloc() : memref<16x6x5x5xf32>
+    %3 = memref.alloc() : memref<120x400xf32>
+    %4 = memref.alloc() : memref<1x120xf32>
+    %5 = memref.alloc() : memref<84x120xf32>
+    %6 = memref.alloc() : memref<1x84xf32>
+    %7 = memref.alloc() : memref<10x84xf32>
+    %8 = memref.alloc() : memref<1x10xf32>
+    %9 = call @conv1(%0, %1) : (memref<1x1x28x28xf32>, memref<6x1x5x5xf32>) -> memref<1x6x28x28xi8>
+    %10 = call @relu(%9) : (memref<1x6x28x28xi8>) -> memref<1x6x28x28xi8>
+    %11 = call @pool(%10) : (memref<1x6x28x28xi8>) -> memref<1x6x14x14xi8>
+    %12 = call @conv2(%11, %2) : (memref<1x6x14x14xi8>, memref<16x6x5x5xf32>) -> memref<1x16x10x10xi8>
+    %13 = call @relu_1(%12) : (memref<1x16x10x10xi8>) -> memref<1x16x10x10xi8>
+    %14 = call @pool_1(%13) : (memref<1x16x10x10xi8>) -> memref<1x16x5x5xi8>
+    %15 = call @flatten(%14) : (memref<1x16x5x5xi8>) -> memref<1x400xi8>
+    %16 = call @fc1(%15, %3, %4) : (memref<1x400xi8>, memref<120x400xf32>, memref<1x120xf32>) -> memref<1x120x!hcl.Fixed<8, 4>>
+    // CHECK: %16 = call @fc1(%15, %3, %4) : (memref<1x400xi8>, memref<120x400xf32>, memref<1x120xf32>) -> memref<1x120xi8>
+    %17 = call @relu_2(%16) : (memref<1x120x!hcl.Fixed<8, 4>>) -> memref<1x120x!hcl.Fixed<8, 4>>
+    // CHECK: %17 = call @relu_2(%16) : (memref<1x120xi8>) -> memref<1x120xi8>
+    %18 = call @fc2(%17, %5, %6) : (memref<1x120x!hcl.Fixed<8, 4>>, memref<84x120xf32>, memref<1x84xf32>) -> memref<1x84x!hcl.Fixed<8, 4>>
+    // CHECK: %18 = call @fc2(%17, %5, %6) : (memref<1x120xi8>, memref<84x120xf32>, memref<1x84xf32>) -> memref<1x84xi8>
+    %19 = call @relu_3(%18) : (memref<1x84x!hcl.Fixed<8, 4>>) -> memref<1x84x!hcl.Fixed<8, 4>>
+    // CHECK: %19 = call @relu_3(%18) : (memref<1x84xi8>) -> memref<1x84xi8>
+    %20 = call @fc3(%19, %7, %8) : (memref<1x84x!hcl.Fixed<8, 4>>, memref<10x84xf32>, memref<1x10xf32>) -> memref<1x10xf32>
+    // CHECK: %20 = call @fc3(%19, %7, %8) : (memref<1x84xi8>, memref<10x84xf32>, memref<1x10xf32>) -> memref<1x10xf32>
+    return
+  }
+}


### PR DESCRIPTION
This PR fixes issue #175 and adds a test case. 

Add support for two things:
- Function declarations with no argument. e.g. `private func @somefunc(Type, Type) -> (Type)`
- `func.call` result update 

Test case added: 
`test/Transforms/datatype/fti_funcsig.mlir`