### PR TITLE
[LLVM][FixedToInt] Add support for `arith::SelectOp` (Fix #177)

### DIFF
--- a/lib/Conversion/FixedPointToInteger.cpp
+++ b/lib/Conversion/FixedPointToInteger.cpp
@@ -51,7 +51,6 @@ Value castIntegerWidth(MLIRContext *ctx, OpBuilder &builder, Location loc,
   return result;
 }
 
-// TODO(Niansong): function calls also need to be handled
 
 /* Update the function signature and
  * Because we need to interact with numpy, which only supports up

--- a/lib/Conversion/FixedPointToInteger.cpp
+++ b/lib/Conversion/FixedPointToInteger.cpp
@@ -985,6 +985,10 @@ void lowerIntToFixed(IntToFixedOp &op) {
   op->replaceAllUsesWith(lshifted);
 }
 
+void updateCallOp(func::CallOp &op) {
+  
+}
+
 // src and dst is guaranteed to be of different fixed types.
 // src: src_width, src_frac
 // dst: dst_width, dst_frac
@@ -1144,6 +1148,8 @@ void visitOperation(Operation &op) {
   } else if (auto new_op = dyn_cast<scf::IfOp>(op)) {
     // llvm::outs() << "IfOp\n";
     updateSCFIfOp(new_op);
+  } else if (auto new_op = dyn_cast<func::CallOp>(op)) {
+    updateCallOp(new_op);
   }
 
   for (auto &region : op.getRegions()) {

--- a/lib/Conversion/FixedPointToInteger.cpp
+++ b/lib/Conversion/FixedPointToInteger.cpp
@@ -51,7 +51,6 @@ Value castIntegerWidth(MLIRContext *ctx, OpBuilder &builder, Location loc,
   return result;
 }
 
-
 /* Update the function signature and
  * Because we need to interact with numpy, which only supports up
  * to 64-bit int/uint, so we update the input/output arguments
@@ -62,8 +61,7 @@ FunctionType updateFunctionSignature(func::FuncOp &funcOp) {
   FunctionType functionType = funcOp.getFunctionType();
   SmallVector<Type, 4> result_types =
       llvm::to_vector<4>(functionType.getResults());
-  SmallVector<Type, 8> arg_types = 
-      llvm::to_vector<8>(functionType.getInputs());
+  SmallVector<Type, 8> arg_types = llvm::to_vector<8>(functionType.getInputs());
 
   SmallVector<Type, 4> new_result_types;
   SmallVector<Type, 8> new_arg_types;
@@ -265,8 +263,9 @@ void updateSelectOp(arith::SelectOp &selectOp) {
   // from fixed-point type to integer type
   Type resType = selectOp.getResult().getType();
   if (resType.isa<FixedType, UFixedType>()) {
-    int bitwidth = resType.isa<FixedType>() ? resType.cast<FixedType>().getWidth()
-                                            : resType.cast<UFixedType>().getWidth();
+    int bitwidth = resType.isa<FixedType>()
+                       ? resType.cast<FixedType>().getWidth()
+                       : resType.cast<UFixedType>().getWidth();
     Type newType = IntegerType::get(selectOp.getContext(), bitwidth);
     selectOp.getResult().setType(newType);
   }
@@ -274,7 +273,7 @@ void updateSelectOp(arith::SelectOp &selectOp) {
   Type op0Type = selectOp.getOperand(1).getType(); // true branch
   Type op1Type = selectOp.getOperand(2).getType(); // false branch
   assert(op0Type == op1Type);
-  assert (op0Type == selectOp.getResult().getType());
+  assert(op0Type == selectOp.getResult().getType());
 }
 
 /* Update hcl.print (PrintOp) operations.
@@ -996,8 +995,8 @@ void lowerIntToFixed(IntToFixedOp &op) {
 
   Value bitAdjusted = castIntegerWidth(op->getContext(), rewriter, loc, src,
                                        dst_width, isSigned);
-  auto lshifted = rewriter.create<arith::ShLIOp>(loc, dstType, bitAdjusted,
-                                                 frac);
+  auto lshifted =
+      rewriter.create<arith::ShLIOp>(loc, dstType, bitAdjusted, frac);
   op->replaceAllUsesWith(lshifted);
 }
 
@@ -1015,9 +1014,8 @@ void updateCallOp(func::CallOp &op) {
     if (MemRefType memrefType = t.dyn_cast<MemRefType>()) {
       Type et = memrefType.getElementType();
       if (et.isa<FixedType, UFixedType>()) {
-        size_t width = et.isa<FixedType>()
-                                ? et.cast<FixedType>().getWidth()
-                                : et.cast<UFixedType>().getWidth();
+        size_t width = et.isa<FixedType>() ? et.cast<FixedType>().getWidth()
+                                           : et.cast<UFixedType>().getWidth();
         Type newElementType = IntegerType::get(op.getContext(), width);
         new_result_types.push_back(memrefType.clone(newElementType));
       } else {
@@ -1026,7 +1024,7 @@ void updateCallOp(func::CallOp &op) {
     } else { // If result type is not memref, error out
       op.emitError("updateCallOp: result type is not memref");
     }
-  } 
+  }
   // set call op result types to new_result_types
   for (auto v : llvm::enumerate(new_result_types)) {
     op.getResult(v.index()).setType(v.value());
@@ -1138,53 +1136,60 @@ void lowerFixedToFixed(FixedToFixedOp &op) {
   }
 }
 
-
 void validateLoweredFunc(func::FuncOp &func) {
   // check if result types and input types are not fixed or ufixed
   FunctionType functionType = func.getFunctionType();
   SmallVector<Type, 4> result_types =
       llvm::to_vector<4>(functionType.getResults());
-  SmallVector<Type, 8> arg_types = 
-      llvm::to_vector<8>(functionType.getInputs()); 
+  SmallVector<Type, 8> arg_types = llvm::to_vector<8>(functionType.getInputs());
   for (auto result_type : result_types) {
     if (result_type.isa<FixedType>() || result_type.isa<UFixedType>()) {
-      func.emitError("FuncOp: " + func.getName().str() + " has fixed-point type result type: " + 
-                      " which means it is not lowered by FixedPointToInteger pass\n");
+      func.emitError(
+          "FuncOp: " + func.getName().str() +
+          " has fixed-point type result type: " +
+          " which means it is not lowered by FixedPointToInteger pass\n");
     }
   }
   for (auto arg_type : arg_types) {
     if (arg_type.isa<FixedType>() || arg_type.isa<UFixedType>()) {
-      func.emitError("FuncOp: " + func.getName().str() + " has fixed-point type arg type: " + 
-                      " which means it is not lowered by FixedPointToInteger pass\n");
+      func.emitError(
+          "FuncOp: " + func.getName().str() +
+          " has fixed-point type arg type: " +
+          " which means it is not lowered by FixedPointToInteger pass\n");
     }
   }
 
   // check if all operations are lowered
-    for (auto &block : func.getBody().getBlocks()) {
-      for (auto &op : block.getOperations()) {
-        // check the result type and arg types of op
-        if (op.getNumResults() > 0) {
-          for (auto result : op.getResults()) {
-            if (result.getType().isa<FixedType>() || result.getType().isa<UFixedType>()) {
-              op.emitError("FuncOp: " + func.getName().str() + " has op: " + std::string(op.getName().getStringRef()) + " with fixed-point result type" + 
-                            " which means it is not lowered by FixedPointToInteger pass\n");
-              llvm::errs() << "op that failed validation: " << op << "\n";
-            }
-          }
-        }
-        // check the arg types of op
-        for (auto arg : op.getOperands()) {
-          if (arg.getType().isa<FixedType>() || arg.getType().isa<UFixedType>()) {
-            op.emitError("FuncOp: " + func.getName().str() + " has op: " + std::string(op.getName().getStringRef()) + " with fixed-point arg type" + 
-                          " which means it is not lowered by FixedPointToInteger pass\n");
+  for (auto &block : func.getBody().getBlocks()) {
+    for (auto &op : block.getOperations()) {
+      // check the result type and arg types of op
+      if (op.getNumResults() > 0) {
+        for (auto result : op.getResults()) {
+          if (result.getType().isa<FixedType>() ||
+              result.getType().isa<UFixedType>()) {
+            op.emitError(
+                "FuncOp: " + func.getName().str() +
+                " has op: " + std::string(op.getName().getStringRef()) +
+                " with fixed-point result type" +
+                " which means it is not lowered by FixedPointToInteger pass\n");
             llvm::errs() << "op that failed validation: " << op << "\n";
           }
         }
       }
+      // check the arg types of op
+      for (auto arg : op.getOperands()) {
+        if (arg.getType().isa<FixedType>() || arg.getType().isa<UFixedType>()) {
+          op.emitError(
+              "FuncOp: " + func.getName().str() +
+              " has op: " + std::string(op.getName().getStringRef()) +
+              " with fixed-point arg type" +
+              " which means it is not lowered by FixedPointToInteger pass\n");
+          llvm::errs() << "op that failed validation: " << op << "\n";
+        }
+      }
     }
+  }
 }
-
-
 
 /// Visitors to recursively update all operations
 void visitOperation(Operation &op);
@@ -1301,6 +1306,8 @@ bool applyFixedPointToInteger(ModuleOp &mod) {
     updateReturnOp(func);
     // llvm::outs() << "updateReturnOp done\n";
     func.setType(newFuncType);
+    // validate
+    validateLoweredFunc(func);
   }
 
   // llvm::outs() << mod << "\n";

--- a/lib/Conversion/FixedPointToInteger.cpp
+++ b/lib/Conversion/FixedPointToInteger.cpp
@@ -63,9 +63,8 @@ FunctionType updateFunctionSignature(func::FuncOp &funcOp) {
   FunctionType functionType = funcOp.getFunctionType();
   SmallVector<Type, 4> result_types =
       llvm::to_vector<4>(functionType.getResults());
-  SmallVector<Type, 8> arg_types;
-  for (const auto &argEn : llvm::enumerate(funcOp.getArguments()))
-    arg_types.push_back(argEn.value().getType());
+  SmallVector<Type, 8> arg_types = 
+      llvm::to_vector<8>(functionType.getInputs());
 
   SmallVector<Type, 4> new_result_types;
   SmallVector<Type, 8> new_arg_types;

--- a/test/Transforms/datatype/fti_funcsig.mlir
+++ b/test/Transforms/datatype/fti_funcsig.mlir
@@ -1,0 +1,45 @@
+// RUN: hcl-opt %s --fixed-to-integer | FileCheck %s
+
+module {
+  func.func private @conv1(memref<1x1x28x28xf32>, memref<6x1x5x5xf32>) -> memref<1x6x28x28xi8>
+  func.func private @relu(memref<1x6x28x28xi8>) -> memref<1x6x28x28xi8>
+  func.func private @pool(memref<1x6x28x28xi8>) -> memref<1x6x14x14xi8>
+  func.func private @conv2(memref<1x6x14x14xi8>, memref<16x6x5x5xf32>) -> memref<1x16x10x10xi8>
+  func.func private @relu_1(memref<1x16x10x10xi8>) -> memref<1x16x10x10xi8>
+  func.func private @pool_1(memref<1x16x10x10xi8>) -> memref<1x16x5x5xi8>
+  func.func private @flatten(memref<1x16x5x5xi8>) -> memref<1x400xi8>
+  func.func private @fc1(memref<1x400xi8>, memref<120x400xf32>, memref<1x120xf32>) -> memref<1x120x!hcl.Fixed<8, 4>>
+  func.func private @relu_2(memref<1x120x!hcl.Fixed<8, 4>>) -> memref<1x120x!hcl.Fixed<8, 4>>
+  func.func private @fc2(memref<1x120x!hcl.Fixed<8, 4>>, memref<84x120xf32>, memref<1x84xf32>) -> memref<1x84x!hcl.Fixed<8, 4>>
+  func.func private @relu_3(memref<1x84x!hcl.Fixed<8, 4>>) -> memref<1x84x!hcl.Fixed<8, 4>>
+  func.func private @fc3(memref<1x84x!hcl.Fixed<8, 4>>, memref<10x84xf32>, memref<1x10xf32>) -> memref<1x10xf32>
+  func.func @main() {
+    %0 = memref.alloc() : memref<1x1x28x28xf32>
+    %1 = memref.alloc() : memref<6x1x5x5xf32>
+    %2 = memref.alloc() : memref<16x6x5x5xf32>
+    %3 = memref.alloc() : memref<120x400xf32>
+    %4 = memref.alloc() : memref<1x120xf32>
+    %5 = memref.alloc() : memref<84x120xf32>
+    %6 = memref.alloc() : memref<1x84xf32>
+    %7 = memref.alloc() : memref<10x84xf32>
+    %8 = memref.alloc() : memref<1x10xf32>
+    %9 = call @conv1(%0, %1) : (memref<1x1x28x28xf32>, memref<6x1x5x5xf32>) -> memref<1x6x28x28xi8>
+    %10 = call @relu(%9) : (memref<1x6x28x28xi8>) -> memref<1x6x28x28xi8>
+    %11 = call @pool(%10) : (memref<1x6x28x28xi8>) -> memref<1x6x14x14xi8>
+    %12 = call @conv2(%11, %2) : (memref<1x6x14x14xi8>, memref<16x6x5x5xf32>) -> memref<1x16x10x10xi8>
+    %13 = call @relu_1(%12) : (memref<1x16x10x10xi8>) -> memref<1x16x10x10xi8>
+    %14 = call @pool_1(%13) : (memref<1x16x10x10xi8>) -> memref<1x16x5x5xi8>
+    %15 = call @flatten(%14) : (memref<1x16x5x5xi8>) -> memref<1x400xi8>
+    %16 = call @fc1(%15, %3, %4) : (memref<1x400xi8>, memref<120x400xf32>, memref<1x120xf32>) -> memref<1x120x!hcl.Fixed<8, 4>>
+    // CHECK: %16 = call @fc1(%15, %3, %4) : (memref<1x400xi8>, memref<120x400xf32>, memref<1x120xf32>) -> memref<1x120xi8>
+    %17 = call @relu_2(%16) : (memref<1x120x!hcl.Fixed<8, 4>>) -> memref<1x120x!hcl.Fixed<8, 4>>
+    // CHECK: %17 = call @relu_2(%16) : (memref<1x120xi8>) -> memref<1x120xi8>
+    %18 = call @fc2(%17, %5, %6) : (memref<1x120x!hcl.Fixed<8, 4>>, memref<84x120xf32>, memref<1x84xf32>) -> memref<1x84x!hcl.Fixed<8, 4>>
+    // CHECK: %18 = call @fc2(%17, %5, %6) : (memref<1x120xi8>, memref<84x120xf32>, memref<1x84xf32>) -> memref<1x84xi8>
+    %19 = call @relu_3(%18) : (memref<1x84x!hcl.Fixed<8, 4>>) -> memref<1x84x!hcl.Fixed<8, 4>>
+    // CHECK: %19 = call @relu_3(%18) : (memref<1x84xi8>) -> memref<1x84xi8>
+    %20 = call @fc3(%19, %7, %8) : (memref<1x84x!hcl.Fixed<8, 4>>, memref<10x84xf32>, memref<1x10xf32>) -> memref<1x10xf32>
+    // CHECK: %20 = call @fc3(%19, %7, %8) : (memref<1x84xi8>, memref<10x84xf32>, memref<1x10xf32>) -> memref<1x10xf32>
+    return
+  }
+}


### PR DESCRIPTION
## Summary
The `fixed-to-integer` pass did not have support for `arith.select` operation that has fixed-point type operands and results. This PR added supports for this case.

## New test case
Added an IR test case here:
`hcl-dialect/test/Transforms/datatype/fixedpoint.mlir`
```mlir
  func.func @select_op(%arg0: memref<10x!hcl.Fixed<8, 4>>, %arg1: memref<10x!hcl.Fixed<8, 4>>) attributes {itypes = "__", otypes = ""} {
    affine.for %arg2 = 0 to 10 {
      %0 = affine.load %arg0[%arg2] {from = "tensor_0"} : memref<10x!hcl.Fixed<8, 4>>
      %c0_i32 = arith.constant 0 : i32
      %1 = hcl.fixed_to_fixed(%0) : !hcl.Fixed<8, 4> -> !hcl.Fixed<36, 4>
      %2 = hcl.int_to_fixed(%c0_i32) : i32 -> !hcl.Fixed<36, 4>
      %3 = hcl.cmp_fixed sgt, %1, %2 : !hcl.Fixed<36, 4>
      %4 = affine.load %arg0[%arg2] {from = "tensor_0"} : memref<10x!hcl.Fixed<8, 4>>
      %5 = hcl.int_to_fixed(%c0_i32) : i32 -> !hcl.Fixed<8, 4>
      %6 = arith.select %3, %4, %5 : !hcl.Fixed<8, 4> // CHECK: i8
      affine.store %6, %arg1[%arg2] {to = "tensor_1"} : memref<10x!hcl.Fixed<8, 4>>
    } {loop_name = "x", op_name = "tensor_1"}
    return
  }
```
This is a fixed-point ReLU operation. I will add the same test in frontend test suite. 