### PR TITLE
[HLS] Fix unsigned type for memref::GlobalOp and reuse_at

### DIFF
--- a/include/hcl/Translation/Utils.h
+++ b/include/hcl/Translation/Utils.h
@@ -85,5 +85,6 @@ private:
 };
 
 void fixUnsignedType(Value &result, bool isUnsigned);
+void fixUnsignedType(memref::GlobalOp &op, bool isUnsigned);
 
 #endif // HCL_TRANSLATION_UTILS_H

--- a/lib/Translation/EmitVivadoHLS.cpp
+++ b/lib/Translation/EmitVivadoHLS.cpp
@@ -1148,6 +1148,7 @@ void ModuleEmitter::emitGlobal(memref::GlobalOp op) {
   auto init_val = op.initial_value();
   if (!init_val.hasValue())
     return;
+  fixUnsignedType(op, op->hasAttr("unsigned"));
   auto attr = init_val.getValue();
   if (auto denseAttr = attr.dyn_cast<DenseElementsAttr>()) {
     os << "\n";
@@ -1184,7 +1185,10 @@ void ModuleEmitter::emitGlobal(memref::GlobalOp op) {
       } else if (type.isInteger(1))
         os << element.cast<BoolAttr>().getValue();
       else if (type.isIntOrIndex())
-        os << element.cast<IntegerAttr>().getValue();
+        if (op->hasAttr("unsigned"))
+          os << element.cast<IntegerAttr>().getValue().getZExtValue();
+        else
+          os << element.cast<IntegerAttr>().getValue();
       else
         emitError(op, "array has unsupported element type.");
 

--- a/lib/Translation/Utils.cpp
+++ b/lib/Translation/Utils.cpp
@@ -83,3 +83,24 @@ void fixUnsignedType(Value &result, bool isUnsigned) {
     }
   }
 }
+
+void fixUnsignedType(memref::GlobalOp &op, bool isUnsigned) {
+  if (isUnsigned) { // unsigned type
+    auto type = op.getTypeAttr().getValue();
+    if (type.isa<MemRefType>()) {
+      auto arrayType = type.dyn_cast<MemRefType>();
+      Type elt = IntegerType::get(
+          arrayType.getContext(),
+          arrayType.getElementType().cast<IntegerType>().getWidth(),
+          IntegerType::SignednessSemantics::Unsigned);
+      // get a memref type attr
+      op.setTypeAttr(TypeAttr::get(MemRefType::get(arrayType.getShape(), elt,
+                                     arrayType.getLayout(),
+                                     arrayType.getMemorySpace())));
+    } else if (type.isa<IntegerType>()) {
+      Type type =
+          IntegerType::get(type.getContext(), type.cast<IntegerType>().getWidth(), IntegerType::SignednessSemantics::Unsigned);
+      op.setTypeAttr(TypeAttr::get(type));
+    }
+  }
+}


### PR DESCRIPTION
As mentioned in the title, the current implementation does not consider data type signedness when constructing the global op or load/store op in reuse_at, which leads to incorrect results. This PR fixes this issue by keeping track of the `unsigned` attribute.