### PR TITLE
[Op] Intra-kernel .to() legality check using Polymer/PoCC in MLIR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,9 @@
 [submodule "externals/openscop"]
 	path = externals/openscop
 	url = https://github.com/periscop/openscop.git
+[submodule "externals/polymer"]
+	path = externals/polymer
+	url = https://github.com/kumasento/polymer.git
 [submodule "externals/llvm-project"]
 	path = externals/llvm-project
 	url = https://github.com/llvm/llvm-project.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "externals/openscop"]
 	path = externals/openscop
 	url = https://github.com/periscop/openscop.git
-[submodule "externals/polymer"]
-	path = externals/polymer
-	url = https://github.com/kumasento/polymer.git
 [submodule "externals/llvm-project"]
 	path = externals/llvm-project
 	url = https://github.com/llvm/llvm-project.git

--- a/include/hcl/Dialect/HeteroCLOps.td
+++ b/include/hcl/Dialect/HeteroCLOps.td
@@ -375,6 +375,26 @@ def HeteroCL_UnrollOp : HeteroCL_Op<"unroll">
     }];
 }
 
+def HeteroCL_UnfoldOp : HeteroCL_Op<"unfold"> 
+{
+    let summary = "unfold";
+    let description = [{
+        hcl.unfold(var, factor=0)
+
+        Unfold the iteration into PE array.
+
+        Parameters
+        * var (IterVar) - The iteration to be unrolled.
+        * factor (Expr) - The unfold factor. Default value  means skip unfolding.
+    }];
+
+    let arguments = (ins LoopHandle:$loop, OptionalAttr<DefaultValuedAttr<UI32Attr,"1">>:$factor);
+    let results = (outs LoopHandle:$result);
+    let assemblyFormat = [{
+        `(` $loop (`,` $factor^)? `)` attr-dict
+    }];
+}
+
 def HeteroCL_PipelineOp : HeteroCL_Op<"pipeline"> 
 {
     let summary = "pipeline";
@@ -389,7 +409,7 @@ def HeteroCL_PipelineOp : HeteroCL_Op<"pipeline">
     }];
 
     let arguments = (ins LoopHandle:$loop, OptionalAttr<DefaultValuedAttr<UI32Attr, "1">>:$ii);
-    let results = (outs );
+    let results = (outs LoopHandle:$result);
     let assemblyFormat = [{
         `(` $loop (`,` $ii^)? `)` attr-dict
     }];
@@ -574,6 +594,19 @@ def HeteroCL_HostXcelToOp : HeteroCL_Op<"host_xcel_to">
     let results = (outs );
     let assemblyFormat = [{
         `(` $target `:` type($target) `,` $device (`,` $axis^)? `)` attr-dict
+    }];
+}
+
+def HeteroCL_IntraKernelToOp : HeteroCL_Op<"intra_kernel_to">
+{
+    let summary = "intra kernel data placement";
+    let description = [{
+        hcl.to(tensor, pes)
+    }];
+    let arguments = (ins AnyMemRef:$target, LoopHandle:$pes);
+    let results = (outs AnyMemRef:$result);
+    let assemblyFormat = [{
+        `(` $target `:` type($target) `,` $pes `)` attr-dict `->` type($result)
     }];
 }
 

--- a/include/hcl/Dialect/HeteroCLOps.td
+++ b/include/hcl/Dialect/HeteroCLOps.td
@@ -597,11 +597,14 @@ def HeteroCL_HostXcelToOp : HeteroCL_Op<"host_xcel_to">
     }];
 }
 
-def HeteroCL_IntraKernelToOp : HeteroCL_Op<"intra_kernel_to">
+def HeteroCL_IntraKernelToOp : HeteroCL_Op<"to">
 {
     let summary = "intra kernel data placement";
     let description = [{
-        hcl.to(tensor, pes)
+        hcl.to(tensor, PEs)
+        ---
+        IntraKernelToOp takes a target memory as input, i.e., $target, and 
+        move the data to a list of PEs as represented by LoopHandle $pes
     }];
     let arguments = (ins AnyMemRef:$target, LoopHandle:$pes);
     let results = (outs AnyMemRef:$result);

--- a/include/hcl/Dialect/HeteroCLOps.td
+++ b/include/hcl/Dialect/HeteroCLOps.td
@@ -604,12 +604,12 @@ def HeteroCL_IntraKernelToOp : HeteroCL_Op<"to">
         hcl.to(tensor, PEs)
         ---
         IntraKernelToOp takes a target memory as input, i.e., $target, and 
-        move the data to a list of PEs as represented by LoopHandle $pes
+        move the data to a list of PEs, i.e., $pe_array 
     }];
-    let arguments = (ins AnyMemRef:$target, LoopHandle:$pes);
+    let arguments = (ins AnyMemRef:$target, LoopHandle:$pe_array);
     let results = (outs AnyMemRef:$result);
     let assemblyFormat = [{
-        `(` $target `:` type($target) `,` $pes `)` attr-dict `->` type($result)
+        `(` $target `:` type($target) `,` $pe_array `)` attr-dict `->` type($result)
     }];
 }
 

--- a/lib/Transforms/LoopTransformations.cpp
+++ b/lib/Transforms/LoopTransformations.cpp
@@ -449,6 +449,10 @@ LogicalResult runReordering(func::FuncOp &f, ReorderOp &reorderOp) {
   return success();
 }
 
+LogicalResult runUnfolding(func::FuncOp &f, UnfoldOp &unfoldOp) {
+  return success();
+}
+
 LogicalResult runUnrolling(func::FuncOp &f, UnrollOp &unrollOp) {
   // 1) Get the schedule
   auto optional_factor = unrollOp.getFactor();

--- a/lib/Transforms/LoopTransformations.cpp
+++ b/lib/Transforms/LoopTransformations.cpp
@@ -474,9 +474,8 @@ LogicalResult runIntraKernelOpCheck(func::FuncOp &f, IntraKernelToOp &intraOp) {
       if (forOp->hasAttr("op_name"))
         isOuterMost = true;
       if (forOp->hasAttr("dep_distance")) {
-        dependency_distance = forOp->getAttr("dep_distance")
-                                  .cast<IntegerAttr>()
-                                  .getInt();
+        dependency_distance =
+            forOp->getAttr("dep_distance").cast<IntegerAttr>().getInt();
       }
     }
   });

--- a/lib/Transforms/LoopTransformations.cpp
+++ b/lib/Transforms/LoopTransformations.cpp
@@ -3459,11 +3459,10 @@ LogicalResult runReform(func::FuncOp &f, ReformOp &reformOp, Value &array) {
 }
 
 bool isHCLOp(Operation &op) {
-  return llvm::isa<SplitOp, TileOp, ReorderOp, UnrollOp, UnfoldOp, 
-                   IntraKernelToOp, PipelineOp, ParallelOp,
-                   FuseOp, ComputeAtOp, PartitionOp, ReuseAtOp, BufferAtOp,
-                   OutlineOp, ReshapeOp, ReformOp, ThreadBindOp,
-                   InterKernelToOp, ReplaceOp>(op);
+  return llvm::isa<SplitOp, TileOp, ReorderOp, UnrollOp, UnfoldOp,
+                   IntraKernelToOp, PipelineOp, ParallelOp, FuseOp, ComputeAtOp,
+                   PartitionOp, ReuseAtOp, BufferAtOp, OutlineOp, ReshapeOp,
+                   ReformOp, ThreadBindOp, InterKernelToOp, ReplaceOp>(op);
 }
 
 void eraseScheduleOp(func::FuncOp &f,

--- a/lib/Transforms/LoopTransformations.cpp
+++ b/lib/Transforms/LoopTransformations.cpp
@@ -452,10 +452,11 @@ LogicalResult runReordering(func::FuncOp &f, ReorderOp &reorderOp) {
 LogicalResult runIntraKernelOpCheck(func::FuncOp &f, IntraKernelToOp &intraOp) {
   // 1) Get the schedule
   auto loopHandle =
-      dyn_cast<CreateLoopHandleOp>(intraOp.pe_array().getDefiningOp());
-  auto opHandle = dyn_cast<CreateOpHandleOp>(loopHandle.op().getDefiningOp());
-  const auto loop_name = loopHandle.loop_name();
-  const auto op_name = opHandle.op_name();
+      dyn_cast<CreateLoopHandleOp>(intraOp.getPeArray().getDefiningOp());
+  auto opHandle =
+      dyn_cast<CreateOpHandleOp>(loopHandle.getOp().getDefiningOp());
+  const auto loop_name = loopHandle.getLoopName();
+  const auto op_name = opHandle.getOpName();
 
   // 2) Find the requested stage
   AffineForOp rootForOp;
@@ -499,20 +500,21 @@ LogicalResult runIntraKernelOpCheck(func::FuncOp &f, IntraKernelToOp &intraOp) {
 
 LogicalResult runUnfolding(func::FuncOp &f, UnfoldOp &unfoldOp) {
   // 1) Get the schedule
-  auto optional_factor = unfoldOp.factor();
+  auto optional_factor = unfoldOp.getFactor();
   unsigned int factor;
 
-  if (optional_factor.hasValue()) {
-    factor = optional_factor.getValue();
+  if (optional_factor.has_value()) {
+    factor = optional_factor.value();
   } else {
     factor = 0; // fully unroll
   }
 
   auto loopHandle =
-      dyn_cast<CreateLoopHandleOp>(unfoldOp.loop().getDefiningOp());
-  const auto loop_name = loopHandle.loop_name();
+      dyn_cast<CreateLoopHandleOp>(unfoldOp.getLoop().getDefiningOp());
+  const auto loop_name = loopHandle.getLoopName();
   const auto op_name =
-      dyn_cast<CreateOpHandleOp>(loopHandle.op().getDefiningOp()).op_name();
+      dyn_cast<CreateOpHandleOp>(loopHandle.getOp().getDefiningOp())
+          .getOpName();
 
   // 2) Find the requested stage
   AffineForOp rootForOp;

--- a/test/Transforms/compute/systolic.mlir
+++ b/test/Transforms/compute/systolic.mlir
@@ -24,7 +24,7 @@ module {
         affine.for %i = 0 to 61 {
             affine.for %j = 0 to 3 {
                 func.call @S0(%i, %j, %C, %j, %A, %W) : (index, index, memref<61xf32>, index, memref<64xf32>, memref<3xf32>) -> ()
-            // CHECK:  } {dep_distance = 0 : i64, loop_name = "i", op_name = "s"} 
+            // CHECK:  } {dep_distance = 1 : i64, loop_name = "j", unroll = 3 : i32}
             } { loop_name = "j", dep_distance = 1 }
         } { loop_name = "i", op_name = "s", dep_distance = 0 }
 

--- a/test/Transforms/compute/systolic.mlir
+++ b/test/Transforms/compute/systolic.mlir
@@ -19,7 +19,7 @@ module {
                 %prod = arith.mulf %a, %b : f32
                 %sum = arith.addf %prod, %c: f32
                 affine.store %sum, %C[%i] : memref<61xf32>
-            // CHECK:  } {dep_disstance = 1 : i64, loop_name = "j", unroll = 3 : i32}
+            // CHECK:  } {dep_distance = 0 : i64, loop_name = "i", op_name = "s"} 
             } { loop_name = "j", dep_distance = 1 }
         } { loop_name = "i", op_name = "s", dep_distance = 0 }
 

--- a/test/Transforms/compute/systolic.mlir
+++ b/test/Transforms/compute/systolic.mlir
@@ -10,6 +10,7 @@ module {
         %li = hcl.create_loop_handle %s, "i"
         %lj = hcl.create_loop_handle %s, "j"
 
+        // Loop nest with attr from PoCC/isl
         affine.for %i = 0 to 61 {
             affine.for %j = 0 to 3 {
                 %a = affine.load %A[%i+%j] : memref<64xf32>
@@ -18,19 +19,14 @@ module {
                 %prod = arith.mulf %a, %b : f32
                 %sum = arith.addf %prod, %c: f32
                 affine.store %sum, %C[%i] : memref<61xf32>
-            } { loop_name = "j" }
-        } { loop_name = "i", op_name = "s" }
+            // CHECK:  } {dep_disstance = 1 : i64, loop_name = "j", unroll = 3 : i32}
+            } { loop_name = "j", dep_distance = 1 }
+        } { loop_name = "i", op_name = "s", dep_distance = 0 }
 
-        // unfolding loop axis into PE array
-        %pe_array = hcl.unfold( %lj, 3 )
-
-        // broadcast weights to PEs
-        hcl.intra_kernel_to(%W : memref<3xf32>, %pe_array) { pe_index = [0,1,2] } -> memref<1xf32>
-
-        // move data across PEs
-        %pe0_w = hcl.intra_kernel_to(%W: memref<3xf32>, %pe_array) { pe_index = [0] } -> memref<1xf32>
-        %pe1_w = hcl.intra_kernel_to(%pe0_w: memref<1xf32>, %pe_array) { pe_index = [1] } -> memref<1xf32>
-
+        %pe_array = hcl.unfold( %lj, 3 ) 
+        hcl.to(%W : memref<3xf32>, %pe_array) { pe_index = [0,1,2] } -> memref<1xf32>
+        %pe0_w = hcl.to(%W: memref<3xf32>, %pe_array) { pe_index = [0] } -> memref<1xf32>
+        %pe1_w = hcl.to(%pe0_w: memref<1xf32>, %pe_array) { pe_index = [1] } -> memref<1xf32>
         return
     }
 }

--- a/test/Transforms/compute/systolic.mlir
+++ b/test/Transforms/compute/systolic.mlir
@@ -4,21 +4,26 @@
 // RUN: hcl-opt -opt %s | FileCheck %s
 
 module {
+    func.func private @S0(%arg0: index, %arg1: index, %arg2: memref<61xf32>, %arg3: index, %arg4: memref<64xf32>, %arg5: memref<3xf32>) attributes {scop.stmt} {
+        %0 = affine.load %arg5[symbol(%arg0)+symbol(%arg1)] : memref<3xf32>
+        %1 = affine.load %arg4[symbol(%arg1)] : memref<64xf32>
+        %2 = arith.mulf %0, %1 : f32
+        %3 = affine.load %arg2[symbol(%arg3)] : memref<61xf32>
+        %4 = arith.addf %2, %3 : f32
+        affine.store %4, %arg2[symbol(%arg3)] : memref<61xf32>
+        return
+    }
+
     func.func @conv1d(%A: memref<64xf32>, %W: memref<3xf32>, %C: memref<61xf32>)
     {
         %s = hcl.create_op_handle "s"
         %li = hcl.create_loop_handle %s, "i"
         %lj = hcl.create_loop_handle %s, "j"
 
-        // Loop nest with attr from PoCC/isl
+        // Polymer (PoCC) post-procssed loop nest
         affine.for %i = 0 to 61 {
             affine.for %j = 0 to 3 {
-                %a = affine.load %A[%i+%j] : memref<64xf32>
-                %b = affine.load %W[%j] : memref<3xf32>
-                %c = affine.load %C[%i] : memref<61xf32>
-                %prod = arith.mulf %a, %b : f32
-                %sum = arith.addf %prod, %c: f32
-                affine.store %sum, %C[%i] : memref<61xf32>
+                func.call @S0(%i, %j, %C, %j, %A, %W) : (index, index, memref<61xf32>, index, memref<64xf32>, memref<3xf32>) -> ()
             // CHECK:  } {dep_distance = 0 : i64, loop_name = "i", op_name = "s"} 
             } { loop_name = "j", dep_distance = 1 }
         } { loop_name = "i", op_name = "s", dep_distance = 0 }

--- a/test/Transforms/compute/systolic.mlir
+++ b/test/Transforms/compute/systolic.mlir
@@ -1,0 +1,36 @@
+// Copyright HeteroCL authors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: hcl-opt -opt %s | FileCheck %s
+
+module {
+    func.func @conv1d(%A: memref<64xf32>, %W: memref<3xf32>, %C: memref<61xf32>)
+    {
+        %s = hcl.create_op_handle "s"
+        %li = hcl.create_loop_handle %s, "i"
+        %lj = hcl.create_loop_handle %s, "j"
+
+        affine.for %i = 0 to 61 {
+            affine.for %j = 0 to 3 {
+                %a = affine.load %A[%i+%j] : memref<64xf32>
+                %b = affine.load %W[%j] : memref<3xf32>
+                %c = affine.load %C[%i] : memref<61xf32>
+                %prod = arith.mulf %a, %b : f32
+                %sum = arith.addf %prod, %c: f32
+                affine.store %sum, %C[%i] : memref<61xf32>
+            } { loop_name = "j" }
+        } { loop_name = "i", op_name = "s" }
+
+        // unfolding loop axis into PE array
+        %pe_array = hcl.unfold( %lj, 3 )
+
+        // broadcast weights to PEs
+        hcl.intra_kernel_to(%W : memref<3xf32>, %pe_array) { pe_index = [0,1,2] } -> memref<1xf32>
+
+        // move data across PEs
+        %pe0_w = hcl.intra_kernel_to(%W: memref<3xf32>, %pe_array) { pe_index = [0] } -> memref<1xf32>
+        %pe1_w = hcl.intra_kernel_to(%pe0_w: memref<1xf32>, %pe_array) { pe_index = [1] } -> memref<1xf32>
+
+        return
+    }
+}


### PR DESCRIPTION
## Summary

In this PR, I implemented the following features. **NB: The names of these operators are subject to changes. We can choose better names later.**
- `hcl.unfold()`. Unfolding loop into spatial PEs. . I chose this name in order to distinguish between the `hcl.unroll()` op, which unrolls the loop by annotating with pragmas.

```c++
// Unfolding the target loop axis into an PE array of %factor PEs
%pe_array = hcl.unfold(%loop_handle, %factor)
```

- `hcl.to()`. Allow users to specify fine-grained data movement between PEs returned by `hcl.unfold()` operator.

```c++
// Broadcast weight %w to all three PEs in the unfolded PE array
%pe0_w = hcl.to(%w,     %pe_array) { "pe_index" = [0,1,2] }
```

## Implementation details
- These two ops will not mutate the AST immediately. Instead, they will annotate the target loop with necessary information. The compiler will pass the annotation to Polymer/PoCC for legality checking before mutating the IR.

- Legality checking: all dependencies should be uniform the dependence distances on space loops should be no greater than one so that the data communication only happens between neighbor PEs. 

- Only when the legality checking passed, our compiler will apply the PE unfolding and inter-PE FIFO insertion. 

## Example
Here is a quick example to build a weight-stationary systolic array using `hcl.unfold()` and `hcl.intra_kernel_to()`:

```c++
module {
    func.func @conv1d(%A: memref<64xf32>, %W: memref<3xf32>, %C: memref<61xf32>)
    {
        %s = hcl.create_op_handle "s"
        %li = hcl.create_loop_handle %s, "i"
        %lj = hcl.create_loop_handle %s, "j"

        // Polymer (PoCC) post-procssed loop nest
        affine.for %i = 0 to 61 {
            affine.for %j = 0 to 3 {
                func.call @S0(%i, %j, %C, %j, %A, %W) : (index, index, memref<61xf32>, index, memref<64xf32>, memref<3xf32>) -> ()
            // CHECK:  } {dep_distance = 0 : i64, loop_name = "i", op_name = "s"} 
            } { loop_name = "j", dep_distance = 1 }
        } { loop_name = "i", op_name = "s", dep_distance = 0 }

        %pe_array = hcl.unfold( %lj, 3 ) 
        hcl.to(%W : memref<3xf32>, %pe_array) { pe_index = [0,1,2] } -> memref<1xf32>
        %pe0_w = hcl.to(%W: memref<3xf32>, %pe_array) { pe_index = [0] } -> memref<1xf32>
        %pe1_w = hcl.to(%pe0_w: memref<1xf32>, %pe_array) { pe_index = [1] } -> memref<1xf32>
        return
    }
}
```


