### PR TITLE
[Transform][AnyWidthInteger] Fix issues with float type arg

### DIFF
--- a/test/Transforms/datatype/anywidth-skip.mlir
+++ b/test/Transforms/datatype/anywidth-skip.mlir
@@ -1,0 +1,9 @@
+// Copyright HeteroCL authors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: hcl-opt %s --lower-anywidth-integer
+module {
+  func.func @kernel(%arg0: memref<4x4xf32>, %arg1: f32, %arg2: f32) -> memref<4x4xf32> attributes {"top"} {
+    return %arg0 : memref<4x4xf32>
+  }
+}


### PR DESCRIPTION
The previous implementation assumed all args and return types are mermef types. This PR fixes the `AnyWidthInteger` pass to skip cases with non-memref type args and return operands. 

The `AnyWidthInteger` pass was added to convert all integer type memref to i64 memref. After https://github.com/cornell-zhang/heterocl/pull/493 is added, I will remove this pass.