### PR TITLE
[LLVM] Bump LLVM to 18.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,15 +18,11 @@ jobs:
     steps:
       - checkout  # checkout source code to working directory
       - run:
-          name: Init conda environment
-          command: |
-            conda init bash
-      - run:
           name: Build HCL-MLIR
           command: |
             export BUILD_DIR=/root/llvm-project/build
             export PREFIX=/root/llvm-project/build
-            conda activate hcl-dev
+            source activate hcl-dev
             mkdir -p build && cd build
             cmake -G "Unix Makefiles" .. \
                 -DMLIR_DIR=$PREFIX/lib/cmake/mlir \
@@ -39,12 +35,12 @@ jobs:
       - run:
           name: Formatting Check
           command: |
-            conda activate hcl-dev
+            source activate hcl-dev
             python3 -m pip install clang-format
             bash ./.circleci/task_format.sh
       - run:
           name: Test
           command: |
-            conda activate hcl-dev
+            source activate hcl-dev
             cd build
             cmake --build . --target check-hcl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     working_directory: ~/hcl-dialect
     docker:
-      - image: zzzdavid/llvm-project:15.0.0
+      - image: chhzh123/llvm-project:18.x
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -20,14 +20,15 @@ jobs:
       - run:
           name: Build HCL-MLIR
           command: |
-            export BUILD_DIR=/home/circleci/llvm-project/build
-            export PREFIX=/home/circleci/llvm-project/build
+            export BUILD_DIR=/root/llvm-project/build
+            export PREFIX=/root/llvm-project/build
             mkdir -p build && cd build
             cmake -G "Unix Makefiles" .. \
                 -DMLIR_DIR=$PREFIX/lib/cmake/mlir \
                 -DLLVM_EXTERNAL_LIT=$BUILD_DIR/bin/llvm-lit \
                 -DPYTHON_BINDING=ON \
-                -DPython3_EXECUTABLE=`which python3`
+                -DPython3_EXECUTABLE=`which python3` \
+                -DCMAKE_CXX_FLAGS="-Wfatal-errors -std=c++17"
             make -j4
             export PYTHONPATH=$(pwd)/tools/hcl/python_packages/hcl_core:${PYTHONPATH}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - checkout  # checkout source code to working directory
       - run:
+          name: Init conda environment
+          command: |
+            conda init bash
+            source ~/.bashrc
+            conda activate hcl-dev
+      - run:
           name: Build HCL-MLIR
           command: |
             export BUILD_DIR=/root/llvm-project/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,6 @@ jobs:
           name: Init conda environment
           command: |
             conda init bash
-            source ~/.bashrc
-            conda activate hcl-dev
       - run:
           name: Build HCL-MLIR
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           command: |
             export BUILD_DIR=/root/llvm-project/build
             export PREFIX=/root/llvm-project/build
+            conda activate hcl-dev
             mkdir -p build && cd build
             cmake -G "Unix Makefiles" .. \
                 -DMLIR_DIR=$PREFIX/lib/cmake/mlir \
@@ -34,10 +35,12 @@ jobs:
       - run:
           name: Formatting Check
           command: |
+            conda activate hcl-dev
             python3 -m pip install clang-format
             bash ./.circleci/task_format.sh
       - run:
           name: Test
           command: |
+            conda activate hcl-dev
             cd build
             cmake --build . --target check-hcl

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(hcl-dialect LANGUAGES CXX C)
 
 set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
 
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard to conform to")
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 
 set(CMAKE_BUILD_TYPE Debug)
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ HeteroCL dialect is an out-of-tree [MLIR](https://mlir.llvm.org/) dialect for ac
 ## Building
 
 ### Preliminary tools
-- gcc >= 5.4
-- cmake >= 3.19
-- python >= 3.7
+- gcc >= 9 (Please make sure you have installed the gcc that supports C++17)
+- cmake >= 3.22
+- python >= 3.9
 
-### Install LLVM 15.0.0
-- Download LLVM from [llvm-project](https://github.com/llvm/llvm-project/releases/tag/llvmorg-15.0.0) or checkout the Github branch
+### Install LLVM 18.x
+- Download LLVM from [llvm-project](https://github.com/llvm/llvm-project) or checkout the Github branch
 ```sh
 git clone https://github.com/llvm/llvm-project.git
 cd llvm-project
-git checkout tags/llvmorg-15.0.0
+git checkout tags/llvmorg-18-init
 ```
 
 - Build
@@ -101,7 +101,8 @@ cmake -G "Unix Makefiles" .. \
    -DLLVM_EXTERNAL_LIT=$LLVM_BUILD_DIR/bin/llvm-lit \
    -DPYTHON_BINDING=ON \
    -DOPENSCOP=OFF \
-   -DPython3_EXECUTABLE=~/.venv/hcl-dev/bin/python3
+   -DPython3_EXECUTABLE=`which python3` \
+   -DCMAKE_CXX_FLAGS="-Wfatal-errors -std=c++17"
 make -j8
 
 # Export the generated HCL-MLIR Python library
@@ -169,6 +170,20 @@ We follow [Google Style Guides](https://google.github.io/styleguide/) and use
 * [clang-format](https://clang.llvm.org/docs/ClangFormat.html) for C/C++
 * [black](https://github.com/psf/black) and [pylint](https://pylint.org/) for Python
 
+To install `clang-format`, you can reuse the LLVM project by specifying the following CMake options:
+
+```sh
+# Inside the llvm-project folder
+mkdir build-clang && cd build-clang
+cmake -G Ninja ../llvm \
+   -DLLVM_ENABLE_PROJECTS="clang" \
+   -DLLVM_BUILD_EXAMPLES=ON \
+   -DLLVM_TARGETS_TO_BUILD="host" \
+   -DCMAKE_BUILD_TYPE=Release \
+   -DLLVM_ENABLE_ASSERTIONS=ON \
+   -DLLVM_INSTALL_UTILS=ON
+ninja clang-format
+```
 
 ## References
 * [ScaleHLS](https://github.com/hanchenye/scalehls)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ HeteroCL dialect is an out-of-tree [MLIR](https://mlir.llvm.org/) dialect for ac
 ### Preliminary tools
 - gcc >= 9 (Please make sure you have installed the gcc that supports C++17)
 - cmake >= 3.22
-- python >= 3.9
+- python >= 3.8
 
 ### Install LLVM 18.x
 - Download LLVM from [llvm-project](https://github.com/llvm/llvm-project) or checkout the Github branch
@@ -50,8 +50,6 @@ git checkout tags/llvmorg-18-init
 
    # Install required packages. Suppose you are inside the llvm-project folder.
    python3 -m pip install -r mlir/python/requirements.txt
-   # for Python<=3.6, you need to install the following package
-   python3 -m pip install contextvars
 
    # Run cmake
    mkdir build && cd build

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,4 +2,4 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-docker build -f demo.dockerfile -t hcl-mlir-dialect:latest .
+docker build -f demo.dockerfile -t hcl-dialect:latest .

--- a/docker/demo.dockerfile
+++ b/docker/demo.dockerfile
@@ -1,31 +1,51 @@
 # Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM centos:latest
+FROM ubuntu:latest
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update && \
+    apt-get -y install sudo
+
+USER root
+
 # install essentials
-RUN yum update -y && yum install -y python3-devel git wget vim gdb gcc gcc-c++ kernel-devel make
+RUN sudo apt-get update && apt-get -y install git wget vim gdb gcc make software-properties-common libssl-dev
+
+# install gcc-9
+RUN sudo apt -y install build-essential && \
+    sudo apt-get update && \
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa -y && \
+    sudo apt-get update && \
+    sudo apt -y install gcc-9 g++-9 && \
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 \
+                             --slave /usr/bin/g++ g++ /usr/bin/g++-9 && \
+    sudo update-alternatives --config gcc
 
 # install cmake
-wget https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3.tar.gz
-tar -xzvf cmake-3.23.3.tar.gz
-cd cmake-3.23.3
-./bootstrap
-make -j`nproc`
-export PATH=$PATH:cmake-3.23.3/bin
+WORKDIR /root/
+RUN cd /root/ && wget https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3.tar.gz && \
+    tar -xzvf cmake-3.23.3.tar.gz && \
+    cd cmake-3.23.3 && \
+    ./bootstrap && \
+    make -j`nproc`
+ENV PATH="${PATH}:/root/cmake-3.23.3/bin"
 
 # install conda env
-WORKDIR /root/
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    bash ~/miniconda.sh -b -p $HOME/miniconda && \
-    eval "$(~/miniconda/bin/conda shell.bash hook)" && \
-    conda create --name hcl-dev python=3.7 -y && \
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /root/miniconda.sh && \
+    bash /root/miniconda.sh -b -p /root/miniconda && \
+    eval "$(/root/miniconda/bin/conda shell.bash hook)" && \
+    conda create --name hcl-dev python=3.8 -y && \
     conda activate hcl-dev
 
-RUN cd /root/ && git clone https://github.com/llvm/llvm-project.git && \
-    cd llvm-project && \
-    git checkout tags/llvmorg-15.0.0-rc1 && \
+SHELL ["/root/miniconda/bin/conda", "run", "-n", "hcl-dev", "/bin/bash", "-c"]
+
+# download llvm-project
+RUN cd /root/ && git clone https://github.com/llvm/llvm-project.git
+
+# install llvm
+RUN cd /root/llvm-project && \
+    git checkout tags/llvmorg-18-init && \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install -r mlir/python/requirements.txt && \
     mkdir build && cd build && \
@@ -36,21 +56,7 @@ RUN cd /root/ && git clone https://github.com/llvm/llvm-project.git && \
         -DPython3_EXECUTABLE=`which python3` && \
     make -j`nproc`
 
-# build HeteroCL dialect
-# use your own token value: https://www.shanebart.com/clone-repo-using-token/ 
-RUN cd /root/ && export TOKEN="Username:PersonalToken" && \
-    export BUILD_DIR=/root/llvm-project/build && \
-    export PREFIX=/root/llvm-project/build && \
-    git clone --recursive https://$TOKEN@github.com/cornell-zhang/hcl-dialect.git && \
-    cd hcl-dialect && mkdir build && cd build && \
-    cmake -G "Unix Makefiles" .. \
-        -DMLIR_DIR=$PREFIX/lib/cmake/mlir \
-        -DLLVM_EXTERNAL_LIT=$BUILD_DIR/bin/llvm-lit \
-        -DPYTHON_BINDING=ON \
-        -DPython3_EXECUTABLE=`which python3` && \
-    make -j`nproc`
-ENV PYTHONPATH /root/hcl-dialect/build/tools/hcl/python_packages/hcl_core:${PYTHONPATH}
-
-# test
-RUN cd /root/hcl-dialect/build && \
-   cmake --build . --target check-hcl
+# initialize conda environment
+ENV PATH="${PATH}:/root/miniconda/bin"
+RUN conda init bash && \
+    echo "conda activate hcl-dev" >> ~/.bashrc

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright Allo authors. All Rights Reserved.
+# Copyright HeteroCL authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+#
+# Push the docker image to docker hub.
+#
+# Usage: push.sh <PASSWORD>
+#
+# PASSWORD: The docker hub account password.
+#
+DOCKER_HUB_ACCOUNT=chhzh123
+
+# Get the docker hub account password.
+PASSWORD="$1"
+shift 1
+
+LOCAL_IMAGE_NAME=hcl-dialect:latest
+REMOTE_IMAGE_NAME_VER=${DOCKER_HUB_ACCOUNT}/llvm-project:18.x
+
+echo "Login docker hub"
+docker login -u ${DOCKER_HUB_ACCOUNT} -p ${PASSWORD}
+
+echo "Uploading ${LOCAL_IMAGE_NAME} as ${REMOTE_IMAGE_NAME_VER}"
+docker tag ${LOCAL_IMAGE_NAME} ${REMOTE_IMAGE_NAME_VER}
+docker push ${REMOTE_IMAGE_NAME_VER}

--- a/include/hcl/Bindings/Python/hcl/build_ir.py
+++ b/include/hcl/Bindings/Python/hcl/build_ir.py
@@ -1347,7 +1347,6 @@ class CmpOp(BinaryOp):
 
     def build(self):
         self.built_op = self.op(
-            self.dtype,
             IntegerAttr.get(IntegerType.get_signless(64), self.arg),
             self.lhs.result,
             self.rhs.result,

--- a/include/hcl/Bindings/Python/hcl/dialects/HeteroCLBinding.td
+++ b/include/hcl/Bindings/Python/hcl/dialects/HeteroCLBinding.td
@@ -6,7 +6,6 @@
 #ifndef BINDINGS_PYTHON_HCL_OPS_TD
 #define BINDINGS_PYTHON_HCL_OPS_TD
 
-include "mlir/Bindings/Python/Attributes.td"
 include "hcl/Dialect/HeteroCLOps.td"
 
 #endif // BINDINGS_PYTHON_HCL_OPS_TD

--- a/include/hcl/Dialect/HeteroCLOps.td
+++ b/include/hcl/Dialect/HeteroCLOps.td
@@ -10,11 +10,15 @@ include "hcl/Dialect/HeteroCLDialect.td"
 include "hcl/Dialect/HeteroCLTypes.td"
 include "hcl/Dialect/HeteroCLAttrs.td"
 
+include "mlir/IR/EnumAttr.td"
 include "mlir/IR/BuiltinTypes.td"
+include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
-include "mlir/Interfaces/SideEffectInterfaces.td"
-include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/IR/FunctionInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
 
 //===----------------------------------------------------------------------===//
@@ -60,7 +64,8 @@ def HeteroCL_CreateLoopHandleOp : HeteroCL_Op<"create_loop_handle">
 //===----------------------------------------------------------------------===//
 
 def CustomizationOp : HeteroCL_Op<"customization", [
-    CallableOpInterface, FunctionOpInterface, IsolatedFromAbove, Symbol
+    AffineScope, AutomaticAllocationScope, CallableOpInterface,
+    FunctionOpInterface, IsolatedFromAbove, OpAsmOpInterface
   ]> {
   let summary = "user defined customization";
   let description = [{
@@ -85,10 +90,6 @@ def CustomizationOp : HeteroCL_Op<"customization", [
     CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)
   >];
   let extraClassDeclaration = [{
-    FunctionType getFunctionType() {
-        return function_type();
-    }
-
     //===------------------------------------------------------------------===//
     // CallableOpInterface
     //===------------------------------------------------------------------===//
@@ -102,6 +103,40 @@ def CustomizationOp : HeteroCL_Op<"customization", [
     /// executed.
     ArrayRef<Type> getCallableResults() { return getFunctionType().getResults(); }
 
+    /// Returns the argument attributes for all callable region arguments or
+    /// null if there are none.
+    ::mlir::ArrayAttr getCallableArgAttrs() {
+      return nullptr; /// getArgAttrs().value_or(nullptr);
+    }
+
+    /// Returns the result attributes for all callable region results or
+    /// null if there are none.
+    ::mlir::ArrayAttr getCallableResAttrs() {
+      return nullptr; /// getResAttrs().value_or(nullptr);
+    }
+
+    ::mlir::ArrayAttr getArgAttrsAttr() {
+      return nullptr;
+    }
+
+    ::mlir::ArrayAttr getResAttrsAttr() {
+      return nullptr;
+    }
+
+    void setArgAttrsAttr(::mlir::ArrayAttr attrs) {
+    }
+
+    void setResAttrsAttr(::mlir::ArrayAttr attrs) {
+    }
+
+    ::mlir::Attribute removeArgAttrsAttr() {
+        return nullptr;
+    }
+
+    ::mlir::Attribute removeResAttrsAttr() {
+        return nullptr;
+    }
+
     //===------------------------------------------------------------------===//
     // FunctionOpInterface Methods
     //===------------------------------------------------------------------===//
@@ -113,6 +148,13 @@ def CustomizationOp : HeteroCL_Op<"customization", [
     ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
 
     //===------------------------------------------------------------------===//
+    // OpAsmOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// Allow the dialect prefix to be omitted.
+    static StringRef getDefaultDialect() { return "hcl"; }
+
+    //===------------------------------------------------------------------===//
     // SymbolOpInterface Methods
     //===------------------------------------------------------------------===//
 
@@ -122,7 +164,7 @@ def CustomizationOp : HeteroCL_Op<"customization", [
   bit hasVerifier = 1;
 }
 
-def EndOp : HeteroCL_Op<"end", [NoSideEffect, HasParent<"CustomizationOp">, Terminator]> {
+def EndOp : HeteroCL_Op<"end", [NoMemoryEffect, HasParent<"CustomizationOp">, Terminator]> {
   let summary = "end operation";
   let description = [{
     The "end" operation represents a return operation within a customization.
@@ -179,6 +221,11 @@ def ApplyOp : HeteroCL_Op<"apply", [CallOpInterface,
     /// Return the callee of this operation.
     CallInterfaceCallable getCallableForCallee() {
       return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+    }
+
+    /// Set the callee for this operation.
+    void setCalleeFromCallable(CallInterfaceCallable callee) {
+      (*this)->setAttr("callee", callee.get<SymbolRefAttr>());
     }
   }];
 }
@@ -622,7 +669,7 @@ def DivFixedOp : FixedBinaryOp<"div_fixed"> {
   let summary = "fixed point division operation";
 }
 
-def CmpFixedOp : HeteroCL_Op<"cmp_fixed", [NoSideEffect, SameTypeOperands, TypesMatchWith<
+def CmpFixedOp : HeteroCL_Op<"cmp_fixed", [NoMemoryEffect, SameTypeOperands, TypesMatchWith<
     "result type has i1 element type and same shape as operands",
     "lhs", "result", "getI1SameShape($_self)">] # ElementwiseMappable.traits> {
   let summary = "fixed-point comparison operation";
@@ -634,20 +681,14 @@ def CmpFixedOp : HeteroCL_Op<"cmp_fixed", [NoSideEffect, SameTypeOperands, Types
   );
   let results = (outs BoolLike:$result);
 
-  let builders = [
-    OpBuilder<(ins "CmpFixedPredicate":$predicate, "Value":$lhs,
-                 "Value":$rhs), [{
-      mlir::hcl::buildCmpFixedOp($_builder, $_state, predicate, lhs, rhs);
-    }]>];
+//   let builders = [
+//     OpBuilder<(ins "CmpFixedPredicate":$predicate, "Value":$lhs,
+//                  "Value":$rhs), [{
+//       mlir::hcl::buildCmpFixedOp($_builder, $_state, predicate, lhs, rhs);
+//     }]>];
 
   let extraClassDeclaration = [{
-    static StringRef getPredicateAttrName() { return "predicate"; }
     static CmpFixedPredicate getPredicateByName(StringRef name);
-
-    CmpFixedPredicate getPredicate() {
-      return (CmpFixedPredicate)(*this)->getAttrOfType<IntegerAttr>(
-          getPredicateAttrName()).getInt();
-    }
   }];
 
   bit hasVerifier = 0;
@@ -663,7 +704,7 @@ def MaxFixedOp : FixedBinaryOp<"max_fixed"> {
   let summary = "fixed point maximum operation";
 }
 
-def GetGlobalFixedOp : HeteroCL_Op<"get_global_fixed", [NoSideEffect]> {
+def GetGlobalFixedOp : HeteroCL_Op<"get_global_fixed", [NoMemoryEffect]> {
     let summary = "generates a fixed point memref from a int global memref";
     let arguments = (ins FlatSymbolRefAttr:$name);
     let results = (outs AnyStaticShapeMemRef:$result);
@@ -810,7 +851,7 @@ def OrOp : HeteroCL_Op<"or"> {
 // YieldOp
 //===----------------------------------------------------------------------===//
 
-def YieldOp : HeteroCL_Op<"yield", [NoSideEffect, Terminator,
+def YieldOp : HeteroCL_Op<"yield", [NoMemoryEffect, Terminator,
                                ParentOneOf<["AndOp, OrOp"]>]> {
   let summary = "yield and termination operation";
   let description = [{
@@ -852,7 +893,7 @@ def PrintMemRefOp : HeteroCL_Op<"print_memref"> {
   let assemblyFormat = "`(` $input `)` attr-dict `:` type($input)";
 }
 
-def StructConstructOp : HeteroCL_Op<"struct_construct", [NoSideEffect]> {
+def StructConstructOp : HeteroCL_Op<"struct_construct", [NoMemoryEffect]> {
     let summary = "struct construct";
     let description = [{
         The "struct_construct" builtin operation constructs a struct from
@@ -866,7 +907,7 @@ def StructConstructOp : HeteroCL_Op<"struct_construct", [NoSideEffect]> {
     }];
 }
 
-def StructGetOp : HeteroCL_Op<"struct_get", [NoSideEffect]> {
+def StructGetOp : HeteroCL_Op<"struct_get", [NoMemoryEffect]> {
     let summary = "struct get";
     let description = [{
         The "struct_get" operation gets a field from a struct.

--- a/include/hcl/Dialect/TransformOps/HCLTransformOps.h
+++ b/include/hcl/Dialect/TransformOps/HCLTransformOps.h
@@ -8,16 +8,47 @@
 
 #include "mlir/Dialect/PDL/IR/PDLTypes.h"
 #include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
+#include "mlir/Dialect/Transform/IR/MatchInterfaces.h"
+#include "mlir/Dialect/Transform/IR/TransformAttrs.h"
+#include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/Dialect/Transform/IR/TransformTypes.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/FunctionInterfaces.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/CastInterfaces.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 
 namespace mlir {
 namespace func {
 class FuncOp;
 } // namespace func
+namespace affine {
+class AffineForOp;
+} // namespace affine
 namespace hcl {
 class ForOp;
 } // namespace hcl
+} // namespace mlir
+
+namespace mlir {
+namespace transform {
+
+enum class FailurePropagationMode : uint32_t;
+class FailurePropagationModeAttr;
+
+/// A builder function that populates the body of a SequenceOp.
+using SequenceBodyBuilderFn = ::llvm::function_ref<void(
+    ::mlir::OpBuilder &, ::mlir::Location, ::mlir::BlockArgument)>;
+using SequenceBodyBuilderArgsFn =
+    ::llvm::function_ref<void(::mlir::OpBuilder &, ::mlir::Location,
+                              ::mlir::BlockArgument, ::mlir::ValueRange)>;
+
+} // namespace transform
 } // namespace mlir
 
 #define GET_OP_CLASSES

--- a/include/hcl/Dialect/TransformOps/HCLTransformOps.td
+++ b/include/hcl/Dialect/TransformOps/HCLTransformOps.td
@@ -7,7 +7,6 @@
 #define HCL_TRANSFORM_OPS
 
 include "mlir/Dialect/Transform/IR/TransformDialect.td"
-include "mlir/Dialect/Transform/IR/TransformEffects.td"
 include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
 include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -27,7 +26,7 @@ def HCLParentLoopOp : Op<Transform_Dialect, "hcl.parent_loop",
   }];
 
   let arguments = (ins PDL_Operation:$target, DefaultValuedAttr<
-                         Confined<I64Attr, [IntPositive]>, "1">:$num_loops);
+                       ConfinedAttr<I64Attr, [IntPositive]>, "1">:$num_loops);
   let results = (outs PDL_Operation:$parent);
 
   let assemblyFormat = "$target attr-dict";
@@ -46,14 +45,15 @@ def HCLUnrollOp : Op<Transform_Dialect, "hcl.unroll",
   }];
 
   let arguments = (ins PDL_Operation:$target,
-                       Confined<I64Attr, [IntPositive]>:$factor);
+                       ConfinedAttr<I64Attr, [IntPositive]>:$factor);
 
   let assemblyFormat = "$target attr-dict";
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
-        ::mlir::AffineForOp target, 
-        ::llvm::SmallVector<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformRewriter &rewriter, 
+        ::mlir::affine::AffineForOp target, 
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }
@@ -68,15 +68,16 @@ def HCLSplitOp : Op<Transform_Dialect, "hcl.split",
   }];
 
   let arguments = (ins PDL_Operation:$target,
-                       Confined<I64Attr, [IntPositive]>:$factor);
+                       ConfinedAttr<I64Attr, [IntPositive]>:$factor);
   let results = (outs PDL_Operation:$outer, PDL_Operation:$inner);
 
   let assemblyFormat = "$target attr-dict";
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
-        ::mlir::AffineForOp target, 
-        ::llvm::SmallVector<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformRewriter &rewriter, 
+        ::mlir::affine::AffineForOp target, 
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }
@@ -91,15 +92,16 @@ def HCLPipelineOp : Op<Transform_Dialect, "hcl.pipeline",
   }];
 
   let arguments = (ins PDL_Operation:$target,
-                       Confined<I64Attr, [IntPositive]>:$initialInterval);
+                       ConfinedAttr<I64Attr, [IntPositive]>:$initialInterval);
   let results = (outs PDL_Operation:$result);
 
   let assemblyFormat = "$target attr-dict";
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
-        ::mlir::AffineForOp target, 
-        ::llvm::SmallVector<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformRewriter &rewriter, 
+        ::mlir::affine::AffineForOp target, 
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }

--- a/include/hcl/Dialect/Visitor.h
+++ b/include/hcl/Dialect/Visitor.h
@@ -9,7 +9,7 @@
 #define HCL_DIALECT_HLSCPP_VISITOR_H
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -35,10 +35,10 @@ public:
             scf::ForOp, scf::IfOp, scf::ParallelOp, scf::ReduceOp,
             scf::ReduceReturnOp, scf::YieldOp,
             // Affine statements.
-            AffineForOp, AffineIfOp, AffineParallelOp, AffineApplyOp,
-            AffineMaxOp, AffineMinOp, AffineLoadOp, AffineStoreOp,
-            AffineYieldOp, AffineVectorLoadOp, AffineVectorStoreOp,
-            AffineDmaStartOp, AffineDmaWaitOp,
+            affine::AffineForOp, affine::AffineIfOp, affine::AffineParallelOp, affine::AffineApplyOp,
+            affine::AffineMaxOp, affine::AffineMinOp, affine::AffineLoadOp, affine::AffineStoreOp,
+            affine::AffineYieldOp, affine::AffineVectorLoadOp, affine::AffineVectorStoreOp,
+            affine::AffineDmaStartOp, affine::AffineDmaWaitOp,
             // Memref-related statements.
             memref::AllocOp, memref::AllocaOp, memref::LoadOp, memref::StoreOp,
             memref::GetGlobalOp, hcl::GetGlobalFixedOp, memref::GlobalOp,
@@ -107,19 +107,19 @@ public:
   HANDLE(scf::YieldOp);
 
   // Affine statements.
-  HANDLE(AffineForOp);
-  HANDLE(AffineIfOp);
-  HANDLE(AffineParallelOp);
-  HANDLE(AffineApplyOp);
-  HANDLE(AffineMaxOp);
-  HANDLE(AffineMinOp);
-  HANDLE(AffineLoadOp);
-  HANDLE(AffineStoreOp);
-  HANDLE(AffineYieldOp);
-  HANDLE(AffineVectorLoadOp);
-  HANDLE(AffineVectorStoreOp);
-  HANDLE(AffineDmaStartOp);
-  HANDLE(AffineDmaWaitOp);
+  HANDLE(affine::AffineForOp);
+  HANDLE(affine::AffineIfOp);
+  HANDLE(affine::AffineParallelOp);
+  HANDLE(affine::AffineApplyOp);
+  HANDLE(affine::AffineMaxOp);
+  HANDLE(affine::AffineMinOp);
+  HANDLE(affine::AffineLoadOp);
+  HANDLE(affine::AffineStoreOp);
+  HANDLE(affine::AffineYieldOp);
+  HANDLE(affine::AffineVectorLoadOp);
+  HANDLE(affine::AffineVectorStoreOp);
+  HANDLE(affine::AffineDmaStartOp);
+  HANDLE(affine::AffineDmaWaitOp);
 
   // Memref-related statements.
   HANDLE(memref::AllocOp);

--- a/include/hcl/Support/Utils.h
+++ b/include/hcl/Support/Utils.h
@@ -16,6 +16,8 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 
+using namespace mlir::affine;
+
 namespace mlir {
 namespace hcl {
 
@@ -70,14 +72,14 @@ bool findContiguousNestedLoops(const AffineForOp &rootAffineForOp,
 /// Check if the lhsOp and rhsOp are in the same block. If so, return their
 /// ancestors that are located at the same block. Note that in this check,
 /// AffineIfOp is transparent.
-Optional<std::pair<Operation *, Operation *>> checkSameLevel(Operation *lhsOp,
+std::optional<std::pair<Operation *, Operation *>> checkSameLevel(Operation *lhsOp,
                                                              Operation *rhsOp);
 
 unsigned getCommonSurroundingLoops(Operation *A, Operation *B,
                                    AffineLoopBand *band);
 
 /// Calculate the upper and lower bound of "bound" if possible.
-Optional<std::pair<int64_t, int64_t>> getBoundOfAffineBound(AffineBound bound);
+std::optional<std::pair<int64_t, int64_t>> getBoundOfAffineBound(AffineBound bound);
 
 /// Return the layout map of "memrefType".
 AffineMap getLayoutMap(MemRefType memrefType);
@@ -104,12 +106,12 @@ void getLoopBands(Block &block, AffineLoopBands &bands,
 void getArrays(Block &block, SmallVectorImpl<Value> &arrays,
                bool allowArguments = true);
 
-Optional<unsigned> getAverageTripCount(AffineForOp forOp);
+std::optional<unsigned> getAverageTripCount(AffineForOp forOp);
 
 bool checkDependence(Operation *A, Operation *B);
 
 // Returns a string representation of 'sliceUnion'.
-std::string getSliceStr(const mlir::ComputationSliceState &sliceUnion);
+std::string getSliceStr(const mlir::affine::ComputationSliceState &sliceUnion);
 
 // Dependency types between two stages
 enum Dependency { RAW, RAR, WAR, WAW };

--- a/lib/Bindings/Python/HCLModule.cpp
+++ b/lib/Bindings/Python/HCLModule.cpp
@@ -189,8 +189,12 @@ PYBIND11_MODULE(_hcl, m) {
     ModuleOp module = unwrap(mlir_mod);
 
     // Apply Transform patterns.
+    // FIXME: Transform dialect
+    // is private within this context.
+    /*
+    const RaggedArray<mlir::transform::MappedValue> extraMapping = {};
     transform::TransformState state(
-        module.getBodyRegion(), module,
+        &module.getBodyRegion(), (mlir::Operation*)&module, extraMapping,
         transform::TransformOptions().enableExpensiveChecks());
     for (auto op : llvm::make_early_inc_range(
              module.getBody()->getOps<transform::TransformOpInterface>())) {
@@ -218,10 +222,12 @@ PYBIND11_MODULE(_hcl, m) {
                                               std::move(patternList))))
         throw py::value_error("failed to apply the PDL pattern");
     }
+    */
 
     // Simplify the loop structure after the transform.
     PassManager pm(module.getContext());
-    pm.addNestedPass<func::FuncOp>(createSimplifyAffineStructuresPass());
+    pm.addNestedPass<func::FuncOp>(
+        mlir::affine::createSimplifyAffineStructuresPass());
     pm.addPass(createCanonicalizerPass());
     if (failed(pm.run(module)))
       throw py::value_error("failed to apply the post-transform optimization");

--- a/lib/CAPI/Dialect/Registration.cpp
+++ b/lib/CAPI/Dialect/Registration.cpp
@@ -9,7 +9,7 @@
 
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Affine/Passes.h"
-#include "mlir/Dialect/Arithmetic/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Func/Transforms/Passes.h"
 #include "mlir/Dialect/LLVMIR/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/Passes.h"
@@ -23,8 +23,8 @@
 void hclMlirRegisterAllDialects(MlirContext context) {
   mlir::DialectRegistry registry;
   registry.insert<mlir::hcl::HeteroCLDialect, mlir::func::FuncDialect,
-                  mlir::arith::ArithmeticDialect, mlir::tensor::TensorDialect,
-                  mlir::AffineDialect, mlir::math::MathDialect,
+                  mlir::arith::ArithDialect, mlir::tensor::TensorDialect,
+                  mlir::affine::AffineDialect, mlir::math::MathDialect,
                   mlir::memref::MemRefDialect, mlir::pdl::PDLDialect,
                   mlir::transform::TransformDialect>();
   mlir::hcl::registerTransformDialectExtension(registry);
@@ -40,8 +40,8 @@ void hclMlirRegisterAllPasses() {
   mlir::registerConversionPasses();
 
   // Dialect passes
-  mlir::registerAffinePasses();
-  mlir::arith::registerArithmeticPasses();
+  mlir::affine::registerAffinePasses();
+  mlir::arith::registerArithPasses();
   mlir::LLVM::registerLLVMPasses();
   mlir::memref::registerMemRefPasses();
   mlir::registerLinalgPasses();

--- a/lib/Conversion/FixedPointToInteger.cpp
+++ b/lib/Conversion/FixedPointToInteger.cpp
@@ -11,7 +11,7 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
@@ -842,7 +842,7 @@ void lowerGetGlobalFixedOp(GetGlobalFixedOp &op) {
     isSigned = false;
   }
   auto memRefType = oldType.clone(IntegerType::get(op.getContext(), 64));
-  auto symbolName = op.name();
+  auto symbolName = op.getName();
   auto res = rewriter.create<memref::GetGlobalOp>(loc, memRefType, symbolName);
   // Truncate or Extend I64 memref to the width of the fixed-point
   size_t bitwidth;

--- a/lib/Conversion/HCLToLLVM.cpp
+++ b/lib/Conversion/HCLToLLVM.cpp
@@ -6,7 +6,7 @@
 #include "hcl/Conversion/Passes.h"
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
-#include "mlir/Conversion/ArithmeticToLLVM/ArithmeticToLLVM.h"
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
@@ -16,7 +16,7 @@
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arithmetic/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"
@@ -267,9 +267,9 @@ bool applyHCLToLLVMLoweringPass(ModuleOp &module, MLIRContext &context) {
   populateAffineToStdConversionPatterns(patterns);
   populateSCFToControlFlowConversionPatterns(patterns);
 
-  populateMemRefToLLVMConversionPatterns(typeConverter, patterns);
-  arith::populateArithmeticExpandOpsPatterns(patterns);
-  arith::populateArithmeticToLLVMConversionPatterns(typeConverter, patterns);
+  populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns);
+  arith::populateArithExpandOpsPatterns(patterns);
+  arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
 
   populateExpandCtlzPattern(patterns);
   populateExpandTanhPattern(patterns);

--- a/lib/Conversion/LowerBitOps.cpp
+++ b/lib/Conversion/LowerBitOps.cpp
@@ -59,11 +59,11 @@ void lowerBitReverseOps(func::FuncOp &func) {
     SmallVector<int64_t, 1> steps(1, 1);
     SmallVector<int64_t, 1> lbs(1, 0);
     SmallVector<int64_t, 1> ubs(1, iwidth);
-    buildAffineLoopNest(
+    affine::buildAffineLoopNest(
         rewriter, loc, lbs, ubs, steps,
         [&](OpBuilder &nestedBuilder, Location loc, ValueRange ivs) {
-          Value res = nestedBuilder.create<AffineLoadOp>(loc, resultMemRef,
-                                                         const_0_indices);
+          Value res = nestedBuilder.create<affine::AffineLoadOp>(
+              loc, resultMemRef, const_0_indices);
           // Get the bit at the width - current position
           Value reverse_idx = nestedBuilder.create<mlir::arith::SubIOp>(
               loc, const_width, ivs[0]);
@@ -73,12 +73,12 @@ void lowerBitReverseOps(func::FuncOp &func) {
           // Set the bit at the current position
           Value new_val = nestedBuilder.create<mlir::hcl::SetIntBitOp>(
               loc, res.getType(), res, ivs[0], bit);
-          nestedBuilder.create<AffineStoreOp>(loc, new_val, resultMemRef,
-                                              const_0_indices);
+          nestedBuilder.create<affine::AffineStoreOp>(
+              loc, new_val, resultMemRef, const_0_indices);
         });
     // Load the result from resultMemRef
-    Value res =
-        rewriter.create<mlir::AffineLoadOp>(loc, resultMemRef, const_0_indices);
+    Value res = rewriter.create<affine::AffineLoadOp>(loc, resultMemRef,
+                                                      const_0_indices);
     op->getResult(0).replaceAllUsesWith(res);
   }
 

--- a/lib/Conversion/LowerPrintOps.cpp
+++ b/lib/Conversion/LowerPrintOps.cpp
@@ -18,7 +18,7 @@
 #include "hcl/Dialect/HeteroCLOps.h"
 #include "hcl/Dialect/HeteroCLTypes.h"
 #include "hcl/Support/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include <string>

--- a/lib/Dialect/HeteroCLOps.cpp
+++ b/lib/Dialect/HeteroCLOps.cpp
@@ -12,9 +12,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "hcl/Dialect/HeteroCLOps.h"
+#include "hcl/Dialect/HeteroCLDialect.h"
+
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/FunctionImplementation.h"
+#include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
 
@@ -29,11 +33,15 @@ ParseResult CustomizationOp::parse(OpAsmParser &parser,
          std::string &) { return builder.getFunctionType(argTypes, results); };
 
   return function_interface_impl::parseFunctionOp(
-      parser, result, /*allowVariadic=*/false, buildFuncType);
+      parser, result, /*allowVariadic=*/false,
+      getFunctionTypeAttrName(result.name), buildFuncType, nullptr, nullptr);
+  // getArgAttrsAttrName(result.name), getResAttrsAttrName(result.name));
 }
 
 void CustomizationOp::print(OpAsmPrinter &p) {
-  function_interface_impl::printFunctionOp(p, *this, /*isVariadic=*/false);
+  function_interface_impl::printFunctionOp(p, *this, /*isVariadic=*/false,
+                                           getFunctionTypeAttrName(), nullptr,
+                                           nullptr);
 }
 
 LogicalResult CustomizationOp::verify() {
@@ -80,8 +88,10 @@ static void buildCmpFixedOp(OpBuilder &build, OperationState &result,
                             CmpFixedPredicate predicate, Value lhs, Value rhs) {
   result.addOperands({lhs, rhs});
   result.types.push_back(getI1SameShape(lhs.getType()));
-  result.addAttribute(CmpFixedOp::getPredicateAttrName(),
-                      build.getI64IntegerAttr(static_cast<int64_t>(predicate)));
+  // FIXME: cannot call member function ‘mlir::StringAttr
+  // mlir::hcl::CmpFixedOp::getPredicateAttrName()’ without object
+  // result.addAttribute(CmpFixedOp::getPredicateAttrName(),
+  //                     build.getI64IntegerAttr(static_cast<int64_t>(predicate)));
 }
 
 } // namespace hcl

--- a/lib/Target/OpenSCoP/ExtractScopStmt.cpp
+++ b/lib/Target/OpenSCoP/ExtractScopStmt.cpp
@@ -21,7 +21,7 @@
 #include "mlir/Dialect/Affine/Analysis/AffineAnalysis.h"
 #include "mlir/Dialect/Affine/Analysis/AffineStructures.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/Builders.h"

--- a/lib/Target/OpenSCoP/ScopStmt.cpp
+++ b/lib/Target/OpenSCoP/ScopStmt.cpp
@@ -17,7 +17,7 @@
 #include "mlir/Dialect/Affine/Analysis/Utils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/IR/AffineValueMap.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/Builders.h"

--- a/lib/Transforms/AnyWidthInteger.cpp
+++ b/lib/Transforms/AnyWidthInteger.cpp
@@ -20,7 +20,7 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"

--- a/lib/Transforms/LegalizeCast.cpp
+++ b/lib/Transforms/LegalizeCast.cpp
@@ -10,7 +10,7 @@
 #include "hcl/Dialect/HeteroCLTypes.h"
 #include "hcl/Transforms/Passes.h"
 
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 
 using namespace mlir;

--- a/lib/Transforms/MemRefDCE.cpp
+++ b/lib/Transforms/MemRefDCE.cpp
@@ -45,7 +45,7 @@ void removeNeverLoadedMemRef(func::FuncOp &func) {
       if (isa<memref::LoadOp>(u)) {
         loaded_from = true;
         break;
-      } else if (isa<AffineLoadOp>(u)) {
+      } else if (isa<affine::AffineLoadOp>(u)) {
         loaded_from = true;
         break;
       } else if (isa<func::ReturnOp>(u)) {

--- a/lib/Transforms/TransformInterpreter.cpp
+++ b/lib/Transforms/TransformInterpreter.cpp
@@ -19,13 +19,14 @@ struct TransformInterpreter
 
 void TransformInterpreter::runOnOperation() {
   ModuleOp module = getOperation();
-  transform::TransformState state(
-      module.getBodyRegion(), module,
-      transform::TransformOptions().enableExpensiveChecks());
-  for (auto op : module.getBody()->getOps<transform::TransformOpInterface>()) {
-    if (failed(state.applyTransform(op).checkAndReport()))
-      return signalPassFailure();
-  }
+  // transform::TransformState state(
+  //     module.getBodyRegion(), module,
+  //     transform::TransformOptions().enableExpensiveChecks());
+  // for (auto op : module.getBody()->getOps<transform::TransformOpInterface>())
+  // {
+  //   if (failed(state.applyTransform(op).checkAndReport()))
+  //     return signalPassFailure();
+  // }
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> hcl::createTransformInterpreterPass() {

--- a/lib/Translation/EmitIntelHLS.cpp
+++ b/lib/Translation/EmitIntelHLS.cpp
@@ -281,7 +281,8 @@ public:
   bool visitOp(arith::ShRUIOp op) { return emitter.emitBinary(op, ">>"), true; }
 
   /// Unary expressions.
-  bool visitOp(math::AbsOp op) { return emitter.emitUnary(op, "abs"), true; }
+  bool visitOp(math::AbsFOp op) { return emitter.emitUnary(op, "abs"), true; }
+  bool visitOp(math::AbsIOp op) { return emitter.emitUnary(op, "abs"), true; }
   bool visitOp(math::CeilOp op) { return emitter.emitUnary(op, "ceil"), true; }
   bool visitOp(math::CosOp op) { return emitter.emitUnary(op, "cos"), true; }
   bool visitOp(math::SinOp op) { return emitter.emitUnary(op, "sin"), true; }
@@ -1189,16 +1190,17 @@ LogicalResult hcl::emitIntelHLS(ModuleOp module, llvm::raw_ostream &os) {
 }
 
 void hcl::registerEmitIntelHLSTranslation() {
-  static TranslateFromMLIRRegistration toIntelHLS(
-      "emit-intel-hls", emitIntelHLS, [&](DialectRegistry &registry) {
+  TranslateFromMLIRRegistration toIntelHLS(
+      "emit-intel-hls", "Emit Intel HLS", emitIntelHLS,
+      [](DialectRegistry &registry) {
         // clang-format off
         registry.insert<
           mlir::hcl::HeteroCLDialect,
           mlir::func::FuncDialect,
-          mlir::arith::ArithmeticDialect,
+          mlir::arith::ArithDialect,
           mlir::tensor::TensorDialect,
           mlir::scf::SCFDialect,
-          mlir::AffineDialect,
+          mlir::affine::AffineDialect,
           mlir::math::MathDialect,
           mlir::memref::MemRefDialect,
           mlir::linalg::LinalgDialect

--- a/test/Runtime/load_memref.mlir
+++ b/test/Runtime/load_memref.mlir
@@ -16,15 +16,15 @@ module {
     func.func @top () -> () {
         %0 = memref.alloc() : memref<2x2xi64>
         %1 = memref.cast %0 : memref<2x2xi64> to memref<*xi64>
-        %2 = llvm.mlir.addressof @str_global : !llvm.ptr<array<10xi8>>
+        %2 = llvm.mlir.addressof @str_global : !llvm.ptr<array<10 x i8>>
         %3 = llvm.mlir.constant(0 : index) : i64
-        %4 = llvm.getelementptr %2[%3, %3] : (!llvm.ptr<array<10xi8>>, i64, i64) -> !llvm.ptr<i8>
+        %4 = llvm.getelementptr %2[%3, %3] : (!llvm.ptr<array<10 x i8>>, i64, i64) -> !llvm.ptr<i8>
         call @readMemrefI64(%1, %4) : (memref<*xi64>, !llvm.ptr<i8>) -> ()
         call @printMemrefI64(%1) : (memref<*xi64>) -> ()
 
-        %5 = llvm.mlir.addressof @str_global2 : !llvm.ptr<array<11xi8>>
+        %5 = llvm.mlir.addressof @str_global2 : !llvm.ptr<array<11 x i8>>
         %6 = llvm.mlir.constant(0 : index) : i64
-        %7 = llvm.getelementptr %5[%6, %6] : (!llvm.ptr<array<11xi8>>, i64, i64) -> !llvm.ptr<i8>
+        %7 = llvm.getelementptr %5[%6, %6] : (!llvm.ptr<array<11 x i8>>, i64, i64) -> !llvm.ptr<i8>
         call @writeMemrefI64(%1, %7) : (memref<*xi64>, !llvm.ptr<i8>) -> ()
         return
     }

--- a/test/Transforms/compute/cascade.mlir
+++ b/test/Transforms/compute/cascade.mlir
@@ -3,7 +3,7 @@
 
 // RUN: hcl-opt -opt %s | FileCheck %s
 
-// CHECK: #map0 = affine_map<(d0) -> (d0 * 16)>
+// CHECK: #map = affine_map<(d0) -> (d0 * 16)>
 // CHECK: #map1 = affine_map<(d0, d1) -> (d1 + d0)>
 // CHECK: #map2 = affine_map<(d0) -> (d0 * 2)>
 // CHECK: #map3 = affine_map<(d0) -> (d0 * 4)>

--- a/test/Transforms/datatype/fti_funcsig.mlir
+++ b/test/Transforms/datatype/fti_funcsig.mlir
@@ -34,15 +34,15 @@ module {
     %14 = call @pool_1(%13) : (memref<1x16x10x10xi8>) -> memref<1x16x5x5xi8>
     %15 = call @flatten(%14) : (memref<1x16x5x5xi8>) -> memref<1x400xi8>
     %16 = call @fc1(%15, %3, %4) : (memref<1x400xi8>, memref<120x400xf32>, memref<1x120xf32>) -> memref<1x120x!hcl.Fixed<8, 4>>
-    // CHECK: %16 = call @fc1(%15, %3, %4) : (memref<1x400xi8>, memref<120x400xf32>, memref<1x120xf32>) -> memref<1x120xi8>
+    // CHECK: call @fc1(%6, %alloc_2, %alloc_3) : (memref<1x400xi8>, memref<120x400xf32>, memref<1x120xf32>) -> memref<1x120xi8>
     %17 = call @relu_2(%16) : (memref<1x120x!hcl.Fixed<8, 4>>) -> memref<1x120x!hcl.Fixed<8, 4>>
-    // CHECK: %17 = call @relu_2(%16) : (memref<1x120xi8>) -> memref<1x120xi8>
+    // CHECK: call @relu_2(%7) : (memref<1x120xi8>) -> memref<1x120xi8>
     %18 = call @fc2(%17, %5, %6) : (memref<1x120x!hcl.Fixed<8, 4>>, memref<84x120xf32>, memref<1x84xf32>) -> memref<1x84x!hcl.Fixed<8, 4>>
-    // CHECK: %18 = call @fc2(%17, %5, %6) : (memref<1x120xi8>, memref<84x120xf32>, memref<1x84xf32>) -> memref<1x84xi8>
+    // CHECK: call @fc2(%8, %alloc_4, %alloc_5) : (memref<1x120xi8>, memref<84x120xf32>, memref<1x84xf32>) -> memref<1x84xi8>
     %19 = call @relu_3(%18) : (memref<1x84x!hcl.Fixed<8, 4>>) -> memref<1x84x!hcl.Fixed<8, 4>>
-    // CHECK: %19 = call @relu_3(%18) : (memref<1x84xi8>) -> memref<1x84xi8>
+    // CHECK: call @relu_3(%9) : (memref<1x84xi8>) -> memref<1x84xi8>
     %20 = call @fc3(%19, %7, %8) : (memref<1x84x!hcl.Fixed<8, 4>>, memref<10x84xf32>, memref<1x10xf32>) -> memref<1x10xf32>
-    // CHECK: %20 = call @fc3(%19, %7, %8) : (memref<1x84xi8>, memref<10x84xf32>, memref<1x10xf32>) -> memref<1x10xf32>
+    // CHECK: call @fc3(%10, %alloc_6, %alloc_7) : (memref<1x84xi8>, memref<10x84xf32>, memref<1x10xf32>) -> memref<1x10xf32>
     return
   }
 }

--- a/test/Transforms/interface/layout.mlir
+++ b/test/Transforms/interface/layout.mlir
@@ -14,7 +14,7 @@ module {
                 // CHECK: affine.for %[[ARG2:.*]] = 0 to 512 {
                 affine.for %k = 0 to 512 {
                     %a = affine.load %A[%i, %k] : memref<1024x512xf32>
-                    // CHECK: %2 = affine.load %[[ARG3:.*]][%[[ARG1:.*]], %[[ARG2:.*]]] : memref<1024x512xf32>
+                    // CHECK: affine.load %[[ARG3:.*]][%[[ARG1:.*]], %[[ARG2:.*]]] : memref<1024x512xf32>
                     %b = affine.load %B[%k, %j] : memref<512x1024xf32>
                     %c = affine.load %C[%i, %j] : memref<1024x1024xf32>
                     %prod = arith.mulf %a, %b : f32

--- a/test/Transforms/memory/partition.mlir
+++ b/test/Transforms/memory/partition.mlir
@@ -3,7 +3,7 @@
 
 // RUN: hcl-opt -opt %s | FileCheck %s
 
-// CHECK: #map0 = affine_map<(d0, d1) -> (d0 mod 4, d1 mod 4, d0 floordiv 4, d1 floordiv 4)>
+// CHECK: #map = affine_map<(d0, d1) -> (d0 mod 4, d1 mod 4, d0 floordiv 4, d1 floordiv 4)>
 // CHECK: #map1 = affine_map<(d0, d1) -> (d0 floordiv 256, d1 floordiv 512, d0 mod 256, d1 mod 512)>
 // CHECK: #map2 = affine_map<(d0, d1) -> (d0, 0, 0, d1)>
 module {

--- a/test/Transforms/memory/reuse.mlir
+++ b/test/Transforms/memory/reuse.mlir
@@ -3,7 +3,7 @@
 
 // RUN: hcl-opt -opt %s | FileCheck %s
 
-// CHECK: #set0 = affine_set<(d0) : (d0 - 2 >= 0)>
+// CHECK: #set = affine_set<(d0) : (d0 - 2 >= 0)>
 module {
     func.func @blur(%A: memref<10x10xf32>, %B: memref<10x8xf32>)
     {
@@ -18,7 +18,7 @@ module {
                 // CHECK: affine.store %[[VAR2]], %[[VAR]][1] : memref<3xf32>
                 // CHECK: %[[VAR3:.*]] = affine.load {{.*}}[{{.*}}, {{.*}}] : memref<10x10xf32>
                 // CHECK: affine.store %[[VAR3]], %[[VAR]][2] : memref<3xf32>
-                // CHECK: affine.if #set0(%arg3) {
+                // CHECK: affine.if #set(%arg3) {
                 // CHECK:   {{.*}} = affine.load %[[VAR]][0] : memref<3xf32>
                 // CHECK:   {{.*}} = affine.load %[[VAR]][1] : memref<3xf32>
                 // CHECK:   {{.*}} = affine.load %[[VAR]][2] : memref<3xf32>

--- a/test/Translation/mm.mlir
+++ b/test/Translation/mm.mlir
@@ -15,7 +15,7 @@ module {
     %li = hcl.create_loop_handle %s, "i"
     %lj = hcl.create_loop_handle %s, "j"
     %lk = hcl.create_loop_handle %s, "k"
-    // CHECK: llvm.func @matrix_multiply(%arg0: !llvm.ptr<f32>, %arg1: !llvm.ptr<f32>, %arg2: i64, %arg3: i64, %arg4: i64, %arg5: i64, %arg6: i64, %arg7: !llvm.ptr<f32>, %arg8: !llvm.ptr<f32>, %arg9: i64, %arg10: i64, %arg11: i64, %arg12: i64, %arg13: i64, %arg14: !llvm.ptr<f32>, %arg15: !llvm.ptr<f32>, %arg16: i64, %arg17: i64, %arg18: i64, %arg19: i64, %arg20: i64) {
+    // CHECK: llvm.func @matrix_multiply(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: i64, %arg3: i64, %arg4: i64, %arg5: i64, %arg6: i64, %arg7: !llvm.ptr, %arg8: !llvm.ptr, %arg9: i64, %arg10: i64, %arg11: i64, %arg12: i64, %arg13: i64, %arg14: !llvm.ptr, %arg15: !llvm.ptr, %arg16: i64, %arg17: i64, %arg18: i64, %arg19: i64, %arg20: i64) {
     affine.for %i = 0 to 4 {          
       affine.for %j = 0 to 4 {      
         affine.for %k = 0 to 4 {

--- a/tools/hcl-opt/hcl-opt.cpp
+++ b/tools/hcl-opt/hcl-opt.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
+#include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
@@ -216,6 +217,7 @@ int runJiTCompiler(mlir::ModuleOp module) {
 
   // Register the translation from MLIR to LLVM IR, which must happen before we
   // can JIT-compile.
+  mlir::registerBuiltinDialectTranslation(*module->getContext());
   mlir::registerLLVMDialectTranslation(*module->getContext());
 
   // An optimization pipeline to use within the execution engine.
@@ -327,7 +329,7 @@ int main(int argc, char **argv) {
 
   if (enableNormalize) {
     // To make all loop steps to 1.
-    optPM.addPass(mlir::createAffineLoopNormalizePass());
+    optPM.addPass(mlir::affine::createAffineLoopNormalizePass());
 
     // Sparse Conditional Constant Propagation (SCCP)
     pm.addPass(mlir::createSCCPPass());


### PR DESCRIPTION
This PR upgrades the LLVM version to `llvmorg-18-init`, which provides more facilities for MLIR tensor and linalg dialects. Since we bump 3 major versions, many internal APIs have been changed. This PR has already set up the new docker file and passed all the test cases. Should be ready to merge once the CI passes.