### PR TITLE
[backend] Add math::abs/pow/ceil Operations to HLS backend

### DIFF
--- a/include/hcl/Dialect/Visitor.h
+++ b/include/hcl/Dialect/Visitor.h
@@ -35,9 +35,10 @@ public:
             scf::ForOp, scf::IfOp, scf::ParallelOp, scf::ReduceOp,
             scf::ReduceReturnOp, scf::YieldOp,
             // Affine statements.
-            affine::AffineForOp, affine::AffineIfOp, affine::AffineParallelOp, affine::AffineApplyOp,
-            affine::AffineMaxOp, affine::AffineMinOp, affine::AffineLoadOp, affine::AffineStoreOp,
-            affine::AffineYieldOp, affine::AffineVectorLoadOp, affine::AffineVectorStoreOp,
+            affine::AffineForOp, affine::AffineIfOp, affine::AffineParallelOp,
+            affine::AffineApplyOp, affine::AffineMaxOp, affine::AffineMinOp,
+            affine::AffineLoadOp, affine::AffineStoreOp, affine::AffineYieldOp,
+            affine::AffineVectorLoadOp, affine::AffineVectorStoreOp,
             affine::AffineDmaStartOp, affine::AffineDmaWaitOp,
             // Memref-related statements.
             memref::AllocOp, memref::AllocaOp, memref::LoadOp, memref::StoreOp,
@@ -48,8 +49,9 @@ public:
             tensor::ExtractOp, tensor::InsertOp, memref::TensorStoreOp,
             tensor::SplatOp, memref::DimOp, memref::RankOp,
             // Unary expressions.
-            math::CosOp, math::SinOp, math::TanhOp, math::SqrtOp, math::RsqrtOp,
-            math::ExpOp, math::Exp2Op, math::PowFOp, math::LogOp, math::Log2Op,
+            math::AbsFOp, math::AbsIOp, math::CeilOp, math::CosOp, math::SinOp,
+            math::TanhOp, math::SqrtOp, math::RsqrtOp, math::ExpOp,
+            math::Exp2Op, math::PowFOp, math::LogOp, math::Log2Op,
             math::Log10Op, arith::NegFOp,
             // Float binary expressions.
             arith::CmpFOp, arith::AddFOp, arith::SubFOp, arith::MulFOp,
@@ -145,6 +147,9 @@ public:
   HANDLE(memref::RankOp);
 
   // Unary expressions.
+  HANDLE(math::AbsFOp);
+  HANDLE(math::AbsIOp);
+  HANDLE(math::CeilOp);
   HANDLE(math::CosOp);
   HANDLE(math::SinOp);
   HANDLE(math::TanhOp);

--- a/lib/Translation/EmitIntelHLS.cpp
+++ b/lib/Translation/EmitIntelHLS.cpp
@@ -111,6 +111,7 @@ public:
   /// Standard expression emitters.
   void emitBinary(Operation *op, const char *syntax);
   void emitUnary(Operation *op, const char *syntax);
+  void emitPower(Operation *op);
 
   /// Special operation emitters.
   void emitConstant(arith::ConstantOp op);
@@ -293,6 +294,7 @@ public:
   }
   bool visitOp(math::ExpOp op) { return emitter.emitUnary(op, "exp"), true; }
   bool visitOp(math::Exp2Op op) { return emitter.emitUnary(op, "exp2"), true; }
+  bool visitOp(math::PowFOp op) { return emitter.emitPower(op), true; }
   bool visitOp(math::LogOp op) { return emitter.emitUnary(op, "log"), true; }
   bool visitOp(math::Log2Op op) { return emitter.emitUnary(op, "log2"), true; }
   bool visitOp(math::Log10Op op) {
@@ -864,6 +866,19 @@ void ModuleEmitter::emitUnary(Operation *op, const char *syntax) {
   emitValue(result, rank);
   os << " = " << syntax << "(";
   emitValue(op->getOperand(0), rank);
+  os << ");";
+  emitInfoAndNewLine(op);
+  emitNestedLoopTail(rank);
+}
+
+void ModuleEmitter::emitPower(Operation *op) {
+  auto rank = emitNestedLoopHead(op->getResult(0));
+  indent();
+  emitValue(op->getResult(0), rank);
+  os << " = pow(";
+  emitValue(op->getOperand(0), rank);
+  os << ", ";
+  emitValue(op->getOperand(1), rank);
   os << ");";
   emitInfoAndNewLine(op);
   emitNestedLoopTail(rank);


### PR DESCRIPTION
As the title mentions, this PR adds the missing `math::abs/pow/ceil` operations to the HLS backend.