### PR TITLE
[Simulation] TaskFlow-based IPs Simulation in HCL-dialect 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "externals/llvm-project"]
 	path = externals/llvm-project
 	url = https://github.com/llvm/llvm-project.git
+[submodule "externals/taskflow"]
+	path = externals/taskflow
+	url = https://github.com/taskflow/taskflow.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ include(AddLLVM)
 include(AddMLIR)
 include(HandleLLVMOptions)
 
+include_directories(${PROJECT_SOURCE_DIR}/externals/taskflow)
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
 include_directories(${PROJECT_SOURCE_DIR}/include)

--- a/tools/hcl-opt/CMakeLists.txt
+++ b/tools/hcl-opt/CMakeLists.txt
@@ -27,6 +27,7 @@ set(LIBS
 add_llvm_executable(hcl-opt hcl-opt.cpp)
 
 llvm_update_compile_flags(hcl-opt)
+target_compile_options(hcl-opt PRIVATE -fexceptions)
 target_link_libraries(hcl-opt PRIVATE ${LIBS})
 
 mlir_check_all_link_libraries(hcl-opt)

--- a/tools/hcl-opt/hcl-opt.cpp
+++ b/tools/hcl-opt/hcl-opt.cpp
@@ -36,6 +36,7 @@
 #include "hcl/Support/Utils.h"
 #include "hcl/Transforms/Passes.h"
 
+#include "taskflow/taskflow.hpp"
 #include <iostream>
 
 static llvm::cl::opt<std::string> inputFilename(llvm::cl::Positional,
@@ -371,8 +372,10 @@ int main(int argc, char **argv) {
   outfile->os() << "\n";
 
   // run JiT
-  if (runJiT)
+  if (runJiT) {
+    tf::Executor executor;
     return runJiTCompiler(*module);
+  }
 
   return 0;
 }


### PR DESCRIPTION

  * We use TaskFlow to simulate multiple IPs running in parallel. Each IP is wrapped inside a TaskFlow worker. We rely on TaskFlow to schedule the execution of each IP. An IP is executed when all its dependent IPs have finished their execution. Inside the TaskFlow worker, we use MLIR’s JIT engine to execute the IP and dump the results as protobuf binary files.

  * We define a `protobuf` specification used to serialize/deserialize the data exchanged between two dependent IPs in the simulation. The data exchange format should track the number of arguments in an IP, and the exact type of each argument. For fixed point data types, the number of bits used to represent the data is also tracked.

  * The serialized data is stored in a protobuf binary file, and the file is passed to the dependent IP as an argument. The dependent IP will deserialize the data and use it as its input.

===== IP Simulator Design =====

  * **Assumption**: in this proposal, we only consider IP in HCL. Specifically, a HCL IP is a module customized with decoupled schedules in hcl-dialect. An HCL IP is reusable and can be instantiated multiple times in a design, and it is internally represented as an MLIR module.

  * **TaskFlow-based IPs simulation**: we use TaskFlow to simulate multiple IPs running in parallel. In the simulation process, each IP is wrapped inside a TaskFlow worker. We rely on TaskFlow to schedule the execution of each IP. An IP is executed when all its dependent IPs have finished their execution. Inside the TaskFlow worker, we use MLIR’s JIT engine to execute the IP and dump the results.

  * **Inter-IP data exchange format**. The simulator should be aware of the data precision schemes used in the IPs when running the actual simulation. The data exchange format should track the number of arguments in an IP, and the exact type of each argument. For fixed point data types, the number of bits used to represent the data is also tracked.

```
syntax = "proto3";

message Param {
  string name = 1;
  string data_type = 2;
  int32 bit_width = 3;
  int32 int_width = 4;
  int32 frac_width = 5;
  float value = 6;
}

message ObjectList {
  repeated Param objects = 1;
}
```

===== Tentative Implementation Plan =====

Add a TaskFlow hook to the HCL dialect after lowering to LLVM IR. The hook will be responsible for: 
  * Creating a TaskFlow worker for the IP
  * Submitting the worker to the TaskFlow scheduler
  * Serializing the output results from the IP into a protobuf binary file when the IP finishes its execution (to be used by its dependent IPs)

