### PR TITLE
[Conversion] Refactor `fixed-to-integer` lowering pass

### DIFF
--- a/lib/Conversion/FixedPointToInteger.cpp
+++ b/lib/Conversion/FixedPointToInteger.cpp
@@ -179,11 +179,6 @@ void updateSelectOp(arith::SelectOp &selectOp) {
     Type newType = IntegerType::get(selectOp.getContext(), bitwidth);
     selectOp.getResult().setType(newType);
   }
-  // Check that the operands of select op have the same type
-  Type op0Type = selectOp.getOperand(1).getType(); // true branch
-  Type op1Type = selectOp.getOperand(2).getType(); // false branch
-  assert(op0Type == op1Type);
-  assert(op0Type == selectOp.getResult().getType());
 }
 
 /* Update hcl.print (PrintOp) operations.

--- a/lib/Conversion/FixedPointToInteger.cpp
+++ b/lib/Conversion/FixedPointToInteger.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/MLIRContext.h"
 
 using namespace mlir;
 using namespace hcl;
@@ -23,26 +24,42 @@ using namespace hcl;
 namespace mlir {
 namespace hcl {
 
-/* Cast integer to target bitwidth
- */
-Value castIntegerWidth(MLIRContext *ctx, OpBuilder &builder, Location loc,
-                       Value v, size_t target_width, bool is_signed) {
-  Value result;
-  Type newType = IntegerType::get(ctx, target_width);
-  if (!v.getType().isa<IntegerType>()) {
-    llvm::errs()
-        << "castIntegerWidth: input is not integer type, input value is: " << v
-        << "\n";
+struct FixedTypeInfo {
+  size_t width;
+  size_t frac;
+  bool isSigned;
+};
+
+FixedTypeInfo getFixedPointInfo(Type t) {
+  FixedTypeInfo info;
+  if (FixedType ft = dyn_cast<FixedType>(t)) {
+    info.width = ft.getWidth();
+    info.frac = ft.getFrac();
+    info.isSigned = true;
+  } else if (UFixedType uft = dyn_cast<UFixedType>(t)) {
+    info.width = uft.getWidth();
+    info.frac = uft.getFrac();
+    info.isSigned = false;
+  } else {
+    llvm::errs() << "getFixedPointInfo: not a fixed-point type <" << t << ">\n";
     assert(false);
   }
-  if (v.getType().cast<IntegerType>().getWidth() < target_width) {
+  return info;
+}
+
+Value castIntegerWidth(MLIRContext *ctx, OpBuilder &builder, Location loc,
+                       Value v, size_t srcWidth, size_t tgtWidth,
+                       bool isSigned) {
+  Value result;
+  Type newType = IntegerType::get(ctx, tgtWidth);
+  if (srcWidth < tgtWidth) {
     // extend bits
-    if (is_signed) {
+    if (isSigned) {
       result = builder.create<arith::ExtSIOp>(loc, newType, v);
     } else {
       result = builder.create<arith::ExtUIOp>(loc, newType, v);
     }
-  } else if (v.getType().cast<IntegerType>().getWidth() > target_width) {
+  } else if (srcWidth > tgtWidth) {
     // truncate bits
     result = builder.create<arith::TruncIOp>(loc, newType, v);
   } else {
@@ -51,13 +68,36 @@ Value castIntegerWidth(MLIRContext *ctx, OpBuilder &builder, Location loc,
   return result;
 }
 
-/* Update the function signature and
- * Because we need to interact with numpy, which only supports up
- * to 64-bit int/uint, so we update the input/output arguments
- * to 64-bit signless integer type. When the input memref
- */
-FunctionType updateFunctionSignature(func::FuncOp &funcOp) {
-  bool isTop = funcOp.getName() == "top";
+Type convertFixedMemRefOrScalarToInt(Type t, MLIRContext *ctx) {
+  if (MemRefType memrefType = t.dyn_cast<MemRefType>()) {
+    // if type is memref
+    Type et = memrefType.getElementType();
+    if (et.isa<FixedType, UFixedType>()) {
+      // if memref element type is fixed-point
+      FixedTypeInfo ti = getFixedPointInfo(et);
+      Type newElementType = IntegerType::get(ctx, ti.width);
+      return memrefType.clone(newElementType);
+    } else {
+      // if memref element type is not fixed-point
+      // make no change
+      return t;
+    }
+  } else {
+    // If type is not memref
+    if (t.isa<FixedType, UFixedType>()) {
+      // if type is fixed-point
+      FixedTypeInfo ti = getFixedPointInfo(t);
+      Type newType = IntegerType::get(ctx, ti.width);
+      return newType;
+    } else {
+      // if type is not fixed-point
+      // make no change
+      return t;
+    }
+  }
+}
+
+void updateFunctionSignature(func::FuncOp &funcOp) {
   FunctionType functionType = funcOp.getFunctionType();
   SmallVector<Type, 4> result_types =
       llvm::to_vector<4>(functionType.getResults());
@@ -66,120 +106,35 @@ FunctionType updateFunctionSignature(func::FuncOp &funcOp) {
   SmallVector<Type, 4> new_result_types;
   SmallVector<Type, 8> new_arg_types;
 
-  // Set the extra type hint based on the input/output memref type
-  std::string itypes = "";
-  if (funcOp->hasAttr("itypes")) {
-    itypes = funcOp->getAttr("itypes").cast<StringAttr>().getValue().str();
-  }
-  std::string otypes = "";
-  if (funcOp->hasAttr("otypes")) {
-    otypes = funcOp->getAttr("otypes").cast<StringAttr>().getValue().str();
-  }
-
   for (auto v : llvm::enumerate(result_types)) {
     Type t = v.value();
-    if (MemRefType memrefType = t.dyn_cast<MemRefType>()) {
-      Type et = memrefType.getElementType();
-      // If result memref element type is fixed
-      // change it to i64 to be compatible with numpy
-      if (et.isa<FixedType, UFixedType>()) {
-        size_t real_width = et.isa<FixedType>()
-                                ? et.cast<FixedType>().getWidth()
-                                : et.cast<UFixedType>().getWidth();
-        size_t width = isTop ? 64 : real_width;
-        Type newElementType = IntegerType::get(funcOp.getContext(), width);
-        new_result_types.push_back(memrefType.clone(newElementType));
-        // update the otypes
-        if (et.isa<FixedType>() && v.index() < otypes.length()) {
-          otypes[v.index()] = 's';
-        } else if (et.isa<UFixedType>() && v.index() < otypes.length()) {
-          otypes[v.index()] = 'u';
-        }
-      } else {
-        new_result_types.push_back(memrefType);
-      }
-    } else { // If result type is not memref, do not change it
-      new_result_types.push_back(t);
-    }
+    Type convertedType =
+        convertFixedMemRefOrScalarToInt(t, funcOp.getContext());
+    new_result_types.push_back(convertedType);
   }
 
   for (auto v : llvm::enumerate(arg_types)) {
     Type t = v.value();
-    if (MemRefType memrefType = t.dyn_cast<MemRefType>()) {
-      Type et = memrefType.getElementType();
-      // If argument memref element type is fixed
-      // change it to i64 to be compatible with numpy
-      if (et.isa<FixedType, UFixedType>()) {
-        size_t real_width = et.isa<FixedType>()
-                                ? et.cast<FixedType>().getWidth()
-                                : et.cast<UFixedType>().getWidth();
-        size_t width = isTop ? 64 : real_width;
-        Type newElementType = IntegerType::get(funcOp.getContext(), width);
-        new_arg_types.push_back(memrefType.clone(newElementType));
-        // update the itypes
-        if (et.isa<FixedType>() and v.index() < itypes.length()) {
-          itypes[v.index()] = 's';
-        } else if (et.isa<UFixedType>() and v.index() < itypes.length()) {
-          itypes[v.index()] = 'u';
-        }
-      } else {
-        new_arg_types.push_back(memrefType);
-      }
-    } else { // If argument type is not memref, do not change it
-      new_arg_types.push_back(t);
-    }
+    Type convertedType =
+        convertFixedMemRefOrScalarToInt(t, funcOp.getContext());
+    new_arg_types.push_back(convertedType);
   }
-
-  funcOp->setAttr("itypes", StringAttr::get(funcOp.getContext(), itypes));
-  funcOp->setAttr("otypes", StringAttr::get(funcOp.getContext(), otypes));
 
   // Update func::FuncOp's block argument types
   for (Block &block : funcOp.getBlocks()) {
     for (unsigned i = 0; i < block.getNumArguments(); i++) {
       Type argType = block.getArgument(i).getType();
-      if (MemRefType memrefType = argType.dyn_cast<MemRefType>()) {
-        Type et = memrefType.getElementType();
-        if (et.isa<FixedType, UFixedType>()) {
-          size_t real_width = et.isa<FixedType>()
-                                  ? et.cast<FixedType>().getWidth()
-                                  : et.cast<UFixedType>().getWidth();
-          size_t width = isTop ? 64 : real_width;
-          Type newType = IntegerType::get(funcOp.getContext(), width);
-          Type newMemRefType = memrefType.clone(newType);
-          // Set block argument type to new memref type
-          block.getArgument(i).setType(newMemRefType);
-          // Truncate the memref type to real_width
-          if (isTop && real_width != 64) {
-            OpBuilder rewriter(funcOp.getBody());
-            Type truncType = IntegerType::get(funcOp.getContext(), real_width);
-            Value truncMemRef = rewriter.create<memref::AllocOp>(
-                block.getArgument(i).getLoc(),
-                memrefType.clone(truncType).cast<MemRefType>());
-            block.getArgument(i).replaceAllUsesWith(truncMemRef);
-            SmallVector<int64_t, 4> lbs(memrefType.getRank(), 0);
-            SmallVector<int64_t, 4> steps(memrefType.getRank(), 1);
-            buildAffineLoopNest(
-                rewriter, block.getArgument(i).getLoc(), lbs,
-                memrefType.getShape(), steps,
-                [&](OpBuilder &nestedBuilder, Location loc, ValueRange ivs) {
-                  Value v = nestedBuilder.create<AffineLoadOp>(
-                      loc, block.getArgument(i), ivs);
-                  Value truncated =
-                      nestedBuilder.create<arith::TruncIOp>(loc, truncType, v);
-                  nestedBuilder.create<AffineStoreOp>(loc, truncated,
-                                                      truncMemRef, ivs);
-                });
-          }
-        }
-      }
+      Type newType =
+          convertFixedMemRefOrScalarToInt(argType, funcOp.getContext());
+      block.getArgument(i).setType(newType);
     }
   }
 
   // Update function signature
   FunctionType newFuncType =
       FunctionType::get(funcOp.getContext(), new_arg_types, new_result_types);
-  // funcOp.setType(newFuncType);
-  return newFuncType;
+  funcOp.setType(newFuncType);
+  return;
 }
 
 /* Update AffineLoad's result type
@@ -188,11 +143,14 @@ memref may change as well, which makes the affine load's result
 type different from input memref's element type. This function
 updates the result type of affine load operations
 */
-void updateAffineLoad(func::FuncOp &f) {
+void updateAffineLoadStore(func::FuncOp &f) {
   SmallVector<Operation *, 10> loads;
+  SmallVector<Operation *, 10> stores;
   f.walk([&](Operation *op) {
     if (auto add_op = dyn_cast<AffineLoadOp>(op)) {
       loads.push_back(op);
+    } else if (auto add_op = dyn_cast<AffineStoreOp>(op)) {
+      stores.push_back(op);
     }
   });
 
@@ -203,58 +161,10 @@ void updateAffineLoad(func::FuncOp &f) {
       op->getResult(v.index()).setType(newType);
     }
   }
-}
-
-/* Update Return Op's arguement value to be i64 memref
- * Check ReturnOp's argument, if it is an AllocOp and
- * it's type is not i64 memref, update it to be i64 memeref
- */
-void updateReturnOp(func::FuncOp &funcOp) {
-  bool isTop = funcOp.getName() == "top";
-  if (!isTop)
-    return; // Only update top function
-  // Update func::FuncOp's return types
-  SmallVector<Operation *, 4> returnOps;
-  funcOp.walk([&](Operation *op) {
-    if (auto add_op = dyn_cast<func::ReturnOp>(op)) {
-      returnOps.push_back(op);
-    }
-  });
-  // get the return type of the function
-  FunctionType funcType = funcOp.getFunctionType();
-  SmallVector<Type, 4> result_types = llvm::to_vector<4>(funcType.getResults());
-
-  // If return op is not int64, we need to add a cast node
-  for (auto op : returnOps) {
-    for (unsigned i = 0; i < op->getNumOperands(); i++) {
-      Value arg = op->getOperand(i);
-      if (MemRefType type = arg.getType().dyn_cast<MemRefType>()) {
-        Type etype = type.getElementType();
-        Type newType = type.clone(IntegerType::get(funcOp.getContext(), 64));
-        if (result_types[i]
-                .cast<MemRefType>()
-                .getElementType()
-                .isa<FixedType, UFixedType>() &&
-            etype != newType) {
-          // if (etype != newType and etype.isa<FixedType, UFixedType>()) {
-          OpBuilder builder(op);
-          Location loc = op->getLoc();
-          // Get signedness hint information
-          std::string otypes = "";
-          if (funcOp->hasAttr("otypes")) {
-            otypes =
-                funcOp->getAttr("otypes").cast<StringAttr>().getValue().str();
-          }
-          bool is_unsigned = false;
-          if (i < otypes.length()) {
-            is_unsigned = otypes[i] == 'u';
-          }
-          Value castedMemRef =
-              castIntMemRef(builder, loc, arg, 64, is_unsigned, false);
-          op->setOperand(i, castedMemRef);
-        }
-      }
-    }
+  for (auto op : stores) {
+    Type newType =
+        op->getOperand(1).getType().cast<MemRefType>().getElementType();
+    op->getOperand(0).setType(newType);
   }
 }
 
@@ -353,159 +263,6 @@ void lowerPrintOp(func::FuncOp &funcOp) {
   }
 }
 
-/* Add attributes to fixed-point operations
- * to preserve operands and result's fixed-type
- * information. After block arguments and
- * affine load operations are updated to integer
- * type, these information will not be directly
- * accessible through operands' types.
- */
-void markFixedArithOps(func::FuncOp &f) {
-  SmallVector<Operation *, 10> fixedOps;
-  f.walk([&](Operation *op) {
-    if (llvm::isa<AddFixedOp, SubFixedOp, MulFixedOp, DivFixedOp, CmpFixedOp,
-                  MinFixedOp, MaxFixedOp>(op)) {
-      fixedOps.push_back(op);
-    }
-  });
-  // set attribute to addOps
-  for (auto op : fixedOps) {
-    // FixedAddOps are binary ops, they have two operands
-    Value opr_l = op->getOperand(0);
-    Value opr_r = op->getOperand(1);
-    Value res = op->getResult(0);
-    size_t lwidth, lfrac, rwidth, rfrac, reswidth, resfrac;
-    // The operands are either fixed-point or unsigned fixed-point
-    if (opr_l.getType().isa<FixedType>()) { // fixed
-      // check that opr_r, res are fixed-point
-      if (!opr_r.getType().isa<FixedType>()) {
-        llvm::errs() << "Error: lhs or rhs are not fixed-point: "
-                     << "operation: " << *op << "\n"
-                     << "lhs type: " << opr_l.getType()
-                     << ", rhs type: " << opr_r.getType()
-                     << ", result type: " << res.getType() << "\n";
-        assert(false);
-      }
-      FixedType ltype = opr_l.getType().cast<FixedType>();
-      FixedType rtype = opr_r.getType().cast<FixedType>();
-      lwidth = ltype.getWidth();
-      lfrac = ltype.getFrac();
-      rwidth = rtype.getWidth();
-      rfrac = rtype.getFrac();
-      if (auto resType = res.getType().dyn_cast<FixedType>()) {
-        reswidth = resType.getWidth();
-        resfrac = resType.getFrac();
-      } else {
-        reswidth = res.getType().getIntOrFloatBitWidth();
-        resfrac = 0;
-      }
-    } else if (opr_l.getType().isa<UFixedType>()) { // ufixed
-      // check that opr_r, res are unsigned fixed-point
-      if (!opr_r.getType().isa<UFixedType>()) {
-        llvm::errs() << "Error: lhs or rhs are not unsigned fixed-point: "
-                     << "operation: " << *op << "\n"
-                     << "lhs type: " << opr_l.getType()
-                     << ", rhs type: " << opr_r.getType()
-                     << ", result type: " << res.getType() << "\n";
-        assert(false);
-      }
-      UFixedType ltype = opr_l.getType().cast<UFixedType>();
-      UFixedType rtype = opr_r.getType().cast<UFixedType>();
-      lwidth = ltype.getWidth();
-      lfrac = ltype.getFrac();
-      rwidth = rtype.getWidth();
-      rfrac = rtype.getFrac();
-      if (auto resType = res.getType().dyn_cast<UFixedType>()) {
-        reswidth = resType.getWidth();
-        resfrac = resType.getFrac();
-      } else {
-        reswidth = res.getType().getIntOrFloatBitWidth();
-        resfrac = 0;
-      }
-    }
-    // if op is MulFixedOp/DivFixedOp, double lwidth, rwidth, and reswidth
-    if (llvm::isa<MulFixedOp>(op) || llvm::isa<DivFixedOp>(op)) {
-      lwidth *= 2;
-      rwidth *= 2;
-      reswidth *= 2;
-    }
-    // add width, frac info as attributes
-    OpBuilder builder(f.getContext());
-    IntegerType targetType = builder.getIntegerType(32);
-    op->setAttr("lwidth", builder.getIntegerAttr(targetType, lwidth));
-    op->setAttr("lfrac", builder.getIntegerAttr(targetType, lfrac));
-    op->setAttr("rwidth", builder.getIntegerAttr(targetType, rwidth));
-    op->setAttr("rfrac", builder.getIntegerAttr(targetType, rfrac));
-    op->setAttr("reswidth", builder.getIntegerAttr(targetType, reswidth));
-    op->setAttr("resfrac", builder.getIntegerAttr(targetType, resfrac));
-    if (opr_l.getType().isa<FixedType>()) {
-      op->setAttr("sign", builder.getStringAttr("signed"));
-    } else {
-      op->setAttr("sign", builder.getStringAttr("unsigned"));
-    }
-  }
-}
-
-/* Add attributes to fixed-point operations
- * to preserve operands and result's fixed-type
- * information. After block arguments and
- * affine load operations are updated to integer
- * type, these information will not be directly
- * accessible through operands' types.
- */
-void markFixedCastOps(func::FuncOp &f) {
-  // collect operations to mark
-  SmallVector<Operation *, 10> fixedOps;
-  f.walk([&](Operation *op) {
-    if (llvm::isa<IntToFixedOp, FixedToIntOp, FloatToFixedOp, FixedToFloatOp,
-                  FixedToFixedOp>(op)) {
-      fixedOps.push_back(op);
-    }
-  });
-  // They are unary ops, they have one operand
-  for (auto op : fixedOps) {
-    OpBuilder builder(f.getContext());
-    Value opr = op->getOperand(0);
-    Value res = op->getResult(0);
-    // Mark operand's fixed-type information
-    if (opr.getType().isa<FixedType>()) {
-      FixedType srcType = opr.getType().cast<FixedType>();
-      size_t width = srcType.getWidth();
-      size_t frac = srcType.getFrac();
-      IntegerType targetType = builder.getIntegerType(32);
-      op->setAttr("src_width", builder.getIntegerAttr(targetType, width));
-      op->setAttr("src_frac", builder.getIntegerAttr(targetType, frac));
-      op->setAttr("src_sign", builder.getStringAttr("signed"));
-    } else if (opr.getType().isa<UFixedType>()) {
-      UFixedType srcType = opr.getType().cast<UFixedType>();
-      size_t width = srcType.getWidth();
-      size_t frac = srcType.getFrac();
-      IntegerType targetType = builder.getIntegerType(32);
-      op->setAttr("src_width", builder.getIntegerAttr(targetType, width));
-      op->setAttr("src_frac", builder.getIntegerAttr(targetType, frac));
-      op->setAttr("src_sign", builder.getStringAttr("unsigned"));
-    }
-    // Mark result's fixed-type information
-    if (res.getType().isa<FixedType>()) {
-      FixedType dstType = res.getType().cast<FixedType>();
-      size_t width = dstType.getWidth();
-      size_t frac = dstType.getFrac();
-      IntegerType targetType = builder.getIntegerType(32);
-      op->setAttr("dst_width", builder.getIntegerAttr(targetType, width));
-      op->setAttr("dst_frac", builder.getIntegerAttr(targetType, frac));
-      op->setAttr("dst_sign", builder.getStringAttr("signed"));
-    } else if (res.getType().isa<UFixedType>()) {
-      UFixedType dstType = res.getType().cast<UFixedType>();
-      size_t width = dstType.getWidth();
-      size_t frac = dstType.getFrac();
-      IntegerType targetType = builder.getIntegerType(32);
-      op->setAttr("dst_width", builder.getIntegerAttr(targetType, width));
-      op->setAttr("dst_frac", builder.getIntegerAttr(targetType, frac));
-      op->setAttr("dst_sign", builder.getStringAttr("unsigned"));
-    }
-  }
-}
-
 // Fixed-point memref allocation op to integer memref
 void updateAlloc(func::FuncOp &f) {
   SmallVector<Operation *, 10> allocOps;
@@ -517,44 +274,9 @@ void updateAlloc(func::FuncOp &f) {
 
   for (auto op : allocOps) {
     auto allocOp = dyn_cast<memref::AllocOp>(op);
-    MemRefType memRefType = allocOp.getType().cast<MemRefType>();
-    Type t = memRefType.getElementType();
-    size_t width;
-    if (auto ft = t.dyn_cast_or_null<FixedType>()) {
-      width = ft.getWidth();
-    } else if (auto uft = t.dyn_cast_or_null<UFixedType>()) {
-      width = uft.getWidth();
-    } else {
-      // Not a fixed-point alloc operation
-      // Return without changing anything
-      continue;
-    }
-    Type newType = IntegerType::get(f.getContext(), width);
-    Type newMemRefType = memRefType.clone(newType);
-    op->getResult(0).setType(newMemRefType); // alloc has only one result
-  }
-}
-
-void updateAffineStore(AffineStoreOp &op) {
-  Type valueTyp = op->getOperand(0).getType();
-  Type memRefEleTyp =
-      op->getOperand(1).getType().cast<MemRefType>().getElementType();
-  OpBuilder builder(op);
-  if (!valueTyp.isa<IntegerType>() || !memRefEleTyp.isa<IntegerType>()) {
-    return;
-  }
-  if (valueTyp.cast<IntegerType>().getWidth() <
-      memRefEleTyp.cast<IntegerType>().getWidth()) {
-    // extend
-    Value v = builder.create<arith::ExtSIOp>(op->getLoc(), memRefEleTyp,
-                                             op->getOperand(0));
-    op->setOperand(0, v);
-  } else if (valueTyp.cast<IntegerType>().getWidth() >
-             memRefEleTyp.cast<IntegerType>().getWidth()) {
-    // truncate
-    Value v = builder.create<arith::TruncIOp>(op->getLoc(), memRefEleTyp,
-                                              op->getOperand(0));
-    op->setOperand(0, v);
+    Type newType =
+        convertFixedMemRefOrScalarToInt(allocOp.getType(), f.getContext());
+    op->getResult(0).setType(newType);
   }
 }
 
@@ -578,74 +300,58 @@ void updateSCFIfOp(mlir::scf::IfOp &op) {
       res.setType(memRefType.clone(eleTyp));
     }
   }
-  // llvm::outs() << op << "\n";
 }
 
 // Lower AddFixedOp to AddIOp
 void lowerFixedAdd(AddFixedOp &op) {
-  size_t width =
-      op->getAttr("lwidth").cast<IntegerAttr>().getValue().getSExtValue();
-  std::string sign = op->getAttr("sign").cast<StringAttr>().getValue().str();
-  bool isSigned = sign == "signed";
   OpBuilder rewriter(op);
-
-  // llvm::outs() << "lhs" << op->getOperand(0) << "\n";
-  // llvm::outs() << "rhs: " << op->getOperand(1) << "\n";
-  Value lhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(0), width, isSigned);
-  Value rhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(1), width, isSigned);
-
-  arith::AddIOp newOp = rewriter.create<arith::AddIOp>(op->getLoc(), lhs, rhs);
+  Type t = op->getOperand(0).getType();
+  FixedTypeInfo ti = getFixedPointInfo(t);
+  auto lhs = op->getOperand(0);
+  auto rhs = op->getOperand(1);
+  Type newType = IntegerType::get(op.getContext(), ti.width);
+  arith::AddIOp newOp =
+      rewriter.create<arith::AddIOp>(op->getLoc(), newType, lhs, rhs);
   op->replaceAllUsesWith(newOp);
 }
 
 // Lower FixedSubOp to SubIOp
 void lowerFixedSub(SubFixedOp &op) {
-  size_t width =
-      op->getAttr("lwidth").cast<IntegerAttr>().getValue().getSExtValue();
-  std::string sign = op->getAttr("sign").cast<StringAttr>().getValue().str();
-  bool isSigned = sign == "signed";
   OpBuilder rewriter(op);
-
-  Value lhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(0), width, isSigned);
-  Value rhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(1), width, isSigned);
-
-  arith::SubIOp newOp = rewriter.create<arith::SubIOp>(op->getLoc(), lhs, rhs);
+  Type t = op->getOperand(0).getType();
+  FixedTypeInfo ti = getFixedPointInfo(t);
+  auto lhs = op->getOperand(0);
+  auto rhs = op->getOperand(1);
+  Type newType = IntegerType::get(op.getContext(), ti.width);
+  arith::SubIOp newOp =
+      rewriter.create<arith::SubIOp>(op->getLoc(), newType, lhs, rhs);
   op->replaceAllUsesWith(newOp);
 }
 
 // Lower MulFixedop to MulIOp
 void lowerFixedMul(MulFixedOp &op) {
-  size_t width =
-      op->getAttr("lwidth").cast<IntegerAttr>().getValue().getSExtValue();
-  size_t frac =
-      op->getAttr("lfrac").cast<IntegerAttr>().getValue().getSExtValue();
-  std::string sign = op->getAttr("sign").cast<StringAttr>().getValue().str();
-  bool isSigned = sign == "signed";
-
+  Type t = op->getOperand(0).getType();
+  FixedTypeInfo ti = getFixedPointInfo(t);
   OpBuilder rewriter(op);
-
-  Value lhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(0), width, isSigned);
-  Value rhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(1), width, isSigned);
-
-  arith::MulIOp newOp = rewriter.create<arith::MulIOp>(op->getLoc(), lhs, rhs);
+  Value lhs =
+      castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
+                       op->getOperand(0), ti.width, ti.width * 2, ti.isSigned);
+  Value rhs =
+      castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
+                       op->getOperand(1), ti.width, ti.width * 2, ti.isSigned);
+  IntegerType intTy = IntegerType::get(op->getContext(), ti.width * 2);
+  IntegerType truncTy = IntegerType::get(op->getContext(), ti.width);
+  arith::MulIOp newOp =
+      rewriter.create<arith::MulIOp>(op->getLoc(), intTy, lhs, rhs);
 
   // lhs<width, frac> * rhs<width, frac> -> res<width, 2*frac>
   // Therefore, we need to right shift the result for frac bit
   // Right shift needs to consider signed/unsigned
-  Type opTy = op->getOperand(0).getType();
-  IntegerType intTy = IntegerType::get(op->getContext(), width);
-  IntegerType truncTy = IntegerType::get(op->getContext(), width / 2);
-  auto fracAttr = rewriter.getIntegerAttr(intTy, frac);
+  auto fracAttr = rewriter.getIntegerAttr(intTy, ti.frac);
   auto fracCstOp =
       rewriter.create<arith::ConstantOp>(op->getLoc(), intTy, fracAttr);
 
-  if (opTy.isa<FixedType>()) {
+  if (ti.isSigned) {
     // use signed right shift
     arith::ShRSIOp res =
         rewriter.create<arith::ShRSIOp>(op->getLoc(), newOp, fracCstOp);
@@ -664,30 +370,26 @@ void lowerFixedMul(MulFixedOp &op) {
 
 // Lower FixedDivOp to DivSIOp/DivUIOp
 void lowerFixedDiv(DivFixedOp &op) {
-  size_t width =
-      op->getAttr("lwidth").cast<IntegerAttr>().getValue().getSExtValue();
-  size_t frac =
-      op->getAttr("lfrac").cast<IntegerAttr>().getValue().getSExtValue();
-  std::string sign = op->getAttr("sign").cast<StringAttr>().getValue().str();
-  bool isSigned = sign == "signed";
-
+  Type t = op->getOperand(0).getType();
+  FixedTypeInfo ti = getFixedPointInfo(t);
   OpBuilder rewriter(op);
-  Value lhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(0), width, isSigned);
-  Value rhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(1), width, isSigned);
+  Value lhs =
+      castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
+                       op->getOperand(0), ti.width, ti.width * 2, ti.isSigned);
+  Value rhs =
+      castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
+                       op->getOperand(1), ti.width, ti.width * 2, ti.isSigned);
   // lhs<width, frac> / rhs<width, frac> -> res<width, 0>
   // Therefore, we need to left shift the lhs for frac bit
   // lhs<width, 2 * frac> / rhs<width, frac> -> res<width, frac>
-  Type opTy = op->getOperand(0).getType();
-  IntegerType intTy = IntegerType::get(op->getContext(), width);
-  IntegerType truncTy = IntegerType::get(op->getContext(), width / 2);
-  auto fracAttr = rewriter.getIntegerAttr(intTy, frac);
+  IntegerType intTy = IntegerType::get(op->getContext(), ti.width * 2);
+  IntegerType truncTy = IntegerType::get(op->getContext(), ti.width);
+  auto fracAttr = rewriter.getIntegerAttr(intTy, ti.frac);
   auto fracCstOp =
       rewriter.create<arith::ConstantOp>(op->getLoc(), intTy, fracAttr);
   arith::ShLIOp lhs_shifted =
       rewriter.create<arith::ShLIOp>(op->getLoc(), lhs, fracCstOp);
-  if (opTy.isa<FixedType>()) { // fixed
+  if (ti.isSigned) { // signed fixed
     arith::DivSIOp res =
         rewriter.create<arith::DivSIOp>(op->getLoc(), lhs_shifted, rhs);
     auto truncated =
@@ -704,25 +406,9 @@ void lowerFixedDiv(DivFixedOp &op) {
 
 // Lower CmpFixedOp to CmpIOp
 void lowerFixedCmp(CmpFixedOp &op) {
-  // llvm::outs() << op << "\n";
-  size_t width =
-      op->getAttr("lwidth").cast<IntegerAttr>().getValue().getSExtValue();
-  std::string sign = op->getAttr("sign").cast<StringAttr>().getValue().str();
-  bool isSigned = sign == "signed";
-  // llvm::outs() << "width: " << width << "\n";
-  // llvm::outs() << "sign: " << sign << "\n";
   OpBuilder rewriter(op);
-
-  Value lhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(0), width, isSigned);
-  Value rhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(1), width, isSigned);
-
-  // llvm::outs() << "lhs: " << lhs << "\n";
-  // llvm::outs() << "rhs: " << rhs << "\n";
-
-  // auto prednum =
-  // op->getAttr("predicate").cast<IntegerAttr>().getValue().getSExtValue();
+  auto lhs = op->getOperand(0);
+  auto rhs = op->getOperand(1);
   auto prednum = op.getPredicate();
   auto loc = op->getLoc();
   arith::CmpIOp newOp;
@@ -771,26 +457,17 @@ void lowerFixedCmp(CmpFixedOp &op) {
     llvm::errs() << "unknown predicate code in CmpFixedOp\n";
   }
 
-  // llvm::outs() << "newOp: " << newOp << "\n";
-
   op->replaceAllUsesWith(newOp);
 }
 
 // Lower MinFixedOp to MinSIOp or MinUIOp
 void lowerFixedMin(MinFixedOp &op) {
-  size_t width =
-      op->getAttr("lwidth").cast<IntegerAttr>().getValue().getSExtValue();
-  std::string sign = op->getAttr("sign").cast<StringAttr>().getValue().str();
-  bool isSigned = sign == "signed";
+  Type t = op->getOperand(0).getType();
+  FixedTypeInfo ti = getFixedPointInfo(t);
   OpBuilder rewriter(op);
-
-  Value lhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(0), width, isSigned);
-  Value rhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(1), width, isSigned);
-
-  Type opTy = op->getOperand(0).getType();
-  if (opTy.isa<FixedType>()) {
+  auto lhs = op->getOperand(0);
+  auto rhs = op->getOperand(1);
+  if (ti.isSigned) {
     // use signed integer min
     auto res = rewriter.create<arith::MinSIOp>(op->getLoc(), lhs, rhs);
     op->replaceAllUsesWith(res);
@@ -803,19 +480,12 @@ void lowerFixedMin(MinFixedOp &op) {
 
 // Lower MaxFixedOp to MaxSIOp or MaxUIOp
 void lowerFixedMax(MaxFixedOp &op) {
-  size_t width =
-      op->getAttr("lwidth").cast<IntegerAttr>().getValue().getSExtValue();
-  std::string sign = op->getAttr("sign").cast<StringAttr>().getValue().str();
-  bool isSigned = sign == "signed";
+  Type t = op->getOperand(0).getType();
+  FixedTypeInfo ti = getFixedPointInfo(t);
   OpBuilder rewriter(op);
-
-  Value lhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(0), width, isSigned);
-  Value rhs = castIntegerWidth(op->getContext(), rewriter, op->getLoc(),
-                               op->getOperand(1), width, isSigned);
-
-  Type opTy = op->getOperand(0).getType();
-  if (opTy.isa<FixedType>()) {
+  auto lhs = op->getOperand(0);
+  auto rhs = op->getOperand(1);
+  if (ti.isSigned) {
     // use signed integer max
     auto res = rewriter.create<arith::MaxSIOp>(op->getLoc(), lhs, rhs);
     op->replaceAllUsesWith(res);
@@ -835,27 +505,13 @@ void lowerGetGlobalFixedOp(GetGlobalFixedOp &op) {
   auto loc = op.getLoc();
   MemRefType oldType = op->getResult(0).getType().dyn_cast<MemRefType>();
   Type oldElementType = oldType.getElementType();
-  bool isSigned;
-  if (auto fixedTy = oldElementType.dyn_cast<FixedType>()) {
-    isSigned = true;
-  } else {
-    isSigned = false;
-  }
+  FixedTypeInfo ti = getFixedPointInfo(oldElementType);
   auto memRefType = oldType.clone(IntegerType::get(op.getContext(), 64));
   auto symbolName = op.getName();
   auto res = rewriter.create<memref::GetGlobalOp>(loc, memRefType, symbolName);
   // Truncate or Extend I64 memref to the width of the fixed-point
-  size_t bitwidth;
-  if (auto fixedType = oldElementType.dyn_cast<FixedType>()) {
-    bitwidth = fixedType.getWidth();
-  } else if (auto ufixedType = oldElementType.dyn_cast<UFixedType>()) {
-    bitwidth = ufixedType.getWidth();
-  } else {
-    llvm::errs() << "unknown fixed-point type in GetGlobalFixedOp\n";
-    return;
-  }
   auto castedMemRefType =
-      oldType.clone(IntegerType::get(op.getContext(), bitwidth))
+      oldType.clone(IntegerType::get(op.getContext(), ti.width))
           .cast<MemRefType>();
   auto castedMemRef = rewriter.create<memref::AllocOp>(loc, castedMemRefType);
   SmallVector<int64_t, 4> lbs(oldType.getRank(), 0);
@@ -865,7 +521,7 @@ void lowerGetGlobalFixedOp(GetGlobalFixedOp &op) {
       [&](OpBuilder &nestedBuilder, Location loc, ValueRange ivs) {
         auto v = nestedBuilder.create<AffineLoadOp>(loc, res, ivs);
         Value casted = castIntegerWidth(op.getContext(), nestedBuilder, loc, v,
-                                        bitwidth, isSigned);
+                                        64, ti.width, ti.isSigned);
         nestedBuilder.create<AffineStoreOp>(loc, casted, castedMemRef, ivs);
       });
 
@@ -884,21 +540,16 @@ void lowerGetGlobalFixedOp(GetGlobalFixedOp &op) {
 }
 
 void lowerFixedToFloat(FixedToFloatOp &op) {
+  Type t = op.getOperand().getType();
+  FixedTypeInfo ti = getFixedPointInfo(t);
   OpBuilder rewriter(op);
-  // size_t src_width =
-  // op->getAttr("src_width").cast<IntegerAttr>().getValue().getSExtValue();
-  size_t src_frac =
-      op->getAttr("src_frac").cast<IntegerAttr>().getValue().getSExtValue();
-  std::string sign =
-      op->getAttr("src_sign").cast<StringAttr>().getValue().str();
-  bool isSigned = sign == "signed";
   auto loc = op.getLoc();
   auto src = op.getOperand();
   auto dst = op.getResult();
   auto dstTy = dst.getType().cast<FloatType>();
   auto frac = rewriter.create<arith::ConstantOp>(
-      loc, dstTy, rewriter.getFloatAttr(dstTy, std::pow(2, src_frac)));
-  if (isSigned) {
+      loc, dstTy, rewriter.getFloatAttr(dstTy, std::pow(2, ti.frac)));
+  if (ti.isSigned) {
     auto res = rewriter.create<arith::SIToFPOp>(loc, dstTy, src);
     auto real = rewriter.create<arith::DivFOp>(loc, dstTy, res, frac);
     op->replaceAllUsesWith(real);
@@ -913,19 +564,14 @@ void lowerFloatToFixed(FloatToFixedOp &op) {
   OpBuilder rewriter(op);
   auto loc = op.getLoc();
   auto src = op.getOperand();
-  size_t dst_width =
-      op->getAttr("dst_width").cast<IntegerAttr>().getValue().getSExtValue();
-  size_t dst_frac =
-      op->getAttr("dst_frac").cast<IntegerAttr>().getValue().getSExtValue();
-  std::string sign =
-      op->getAttr("dst_sign").cast<StringAttr>().getValue().str();
-  bool isSigned = sign == "signed";
+  Type t = op.getResult().getType();
+  FixedTypeInfo ti = getFixedPointInfo(t);
   auto FType = src.getType().cast<FloatType>();
   auto frac = rewriter.create<arith::ConstantOp>(
-      loc, FType, rewriter.getFloatAttr(FType, std::pow(2, dst_frac)));
-  auto dstType = IntegerType::get(op.getContext(), dst_width);
+      loc, FType, rewriter.getFloatAttr(FType, std::pow(2, ti.frac)));
+  auto dstType = IntegerType::get(op.getContext(), ti.width);
   auto FEncoding = rewriter.create<arith::MulFOp>(loc, FType, src, frac);
-  if (isSigned) {
+  if (ti.isSigned) {
     auto IEncoding = rewriter.create<arith::FPToSIOp>(loc, dstType, FEncoding);
     op->replaceAllUsesWith(IEncoding);
   } else {
@@ -939,19 +585,16 @@ void lowerFixedToInt(FixedToIntOp &op) {
   auto loc = op.getLoc();
   auto src = op.getOperand();
   auto dst = op.getResult();
-  size_t src_width =
-      op->getAttr("src_width").cast<IntegerAttr>().getValue().getSExtValue();
-  size_t src_frac =
-      op->getAttr("src_frac").cast<IntegerAttr>().getValue().getSExtValue();
-  std::string sign =
-      op->getAttr("src_sign").cast<StringAttr>().getValue().str();
-  bool isSigned = sign == "signed";
+  Type t = src.getType();
+  FixedTypeInfo ti = getFixedPointInfo(t);
+  auto src_width = ti.width;
+  auto src_frac = ti.frac;
   auto dstType = dst.getType().cast<IntegerType>();
   auto srcType = IntegerType::get(op.getContext(), src_width);
   size_t dst_width = dstType.getWidth();
   auto frac = rewriter.create<arith::ConstantOp>(
       loc, srcType, rewriter.getIntegerAttr(srcType, src_frac));
-  if (isSigned) {
+  if (ti.isSigned) {
     auto rshifted = rewriter.create<arith::ShRSIOp>(loc, srcType, src, frac);
     if (dst_width > src_width) {
       auto res = rewriter.create<arith::ExtSIOp>(loc, dstType, rshifted);
@@ -980,21 +623,18 @@ void lowerIntToFixed(IntToFixedOp &op) {
   OpBuilder rewriter(op);
   auto loc = op.getLoc();
   auto src = op.getOperand();
-  size_t dst_width =
-      op->getAttr("dst_width").cast<IntegerAttr>().getValue().getSExtValue();
-  size_t dst_frac =
-      op->getAttr("dst_frac").cast<IntegerAttr>().getValue().getSExtValue();
-  std::string sign =
-      op->getAttr("dst_sign").cast<StringAttr>().getValue().str();
-  bool isSigned = sign == "signed";
-  auto srcType = src.getType().cast<IntegerType>();
+  auto dst = op.getResult();
+  Type t = dst.getType();
+  FixedTypeInfo ti = getFixedPointInfo(t);
+  auto src_width = src.getType().cast<IntegerType>().getWidth();
+  auto dst_width = ti.width;
+  auto dst_frac = ti.frac;
   auto dstType = IntegerType::get(op.getContext(), dst_width);
-  // size_t src_width = srcType.getWidth();
   auto frac = rewriter.create<arith::ConstantOp>(
       loc, dstType, rewriter.getIntegerAttr(dstType, dst_frac));
 
   Value bitAdjusted = castIntegerWidth(op->getContext(), rewriter, loc, src,
-                                       dst_width, isSigned);
+                                       src_width, dst_width, ti.isSigned);
   auto lshifted =
       rewriter.create<arith::ShLIOp>(loc, dstType, bitAdjusted, frac);
   op->replaceAllUsesWith(lshifted);
@@ -1049,26 +689,14 @@ void lowerFixedToFixed(FixedToFixedOp &op) {
   OpBuilder rewriter(op);
   auto loc = op.getLoc();
   auto src = op.getOperand();
-  size_t src_width =
-      op->getAttr("src_width").cast<IntegerAttr>().getValue().getSExtValue();
-  size_t src_frac =
-      op->getAttr("src_frac").cast<IntegerAttr>().getValue().getSExtValue();
-  size_t dst_width =
-      op->getAttr("dst_width").cast<IntegerAttr>().getValue().getSExtValue();
-  size_t dst_frac =
-      op->getAttr("dst_frac").cast<IntegerAttr>().getValue().getSExtValue();
-
-  std::string src_sign =
-      op->getAttr("src_sign").cast<StringAttr>().getValue().str();
-  std::string dst_sign =
-      op->getAttr("dst_sign").cast<StringAttr>().getValue().str();
-  bool isSignedSrc = src_sign == "signed";
-  // bool isSignedDst = dst_sign == "signed";
-
-  // auto srcType = src.getType().cast<IntegerType>();
-  // if (srcType.getWidth() != src_width) {
-  //   llvm::errs() << "src_width != srcType.getWidth()\n";
-  // }
+  auto dst = op.getResult();
+  FixedTypeInfo src_ti = getFixedPointInfo(src.getType());
+  FixedTypeInfo dst_ti = getFixedPointInfo(dst.getType());
+  size_t src_width = src_ti.width;
+  size_t src_frac = src_ti.frac;
+  size_t dst_width = dst_ti.width;
+  size_t dst_frac = dst_ti.frac;
+  bool isSignedSrc = src_ti.isSigned;
   auto srcType = IntegerType::get(op.getContext(), src_width);
   auto dstType = IntegerType::get(op.getContext(), dst_width);
 
@@ -1198,52 +826,32 @@ void visitBlock(Block &block);
 
 void visitOperation(Operation &op) {
   if (auto new_op = dyn_cast<AddFixedOp>(op)) {
-    // llvm::outs() << "AddFixedOp\n";
     lowerFixedAdd(new_op);
   } else if (auto new_op = dyn_cast<SubFixedOp>(op)) {
-    // llvm::outs() << "SubFixedOp\n";
     lowerFixedSub(new_op);
   } else if (auto new_op = dyn_cast<MulFixedOp>(op)) {
-    // llvm::outs() << "MulFixedOp\n";
     lowerFixedMul(new_op);
   } else if (auto new_op = dyn_cast<DivFixedOp>(op)) {
-    // llvm::outs() << "DivFixedOp\n";
     lowerFixedDiv(new_op);
   } else if (auto new_op = dyn_cast<CmpFixedOp>(op)) {
-    // llvm::outs() << "CmpFixedOp\n";
     lowerFixedCmp(new_op);
   } else if (auto new_op = dyn_cast<MinFixedOp>(op)) {
-    // llvm::outs() << "MinFixedOp\n";
     lowerFixedMin(new_op);
   } else if (auto new_op = dyn_cast<MaxFixedOp>(op)) {
-    // llvm::outs() << "MaxFixedOp\n";
     lowerFixedMax(new_op);
-  } else if (auto new_op = dyn_cast<AffineStoreOp>(op)) {
-    // llvm::outs() << "AffineStoreOp\n";
-    updateAffineStore(new_op);
   } else if (auto new_op = dyn_cast<GetGlobalFixedOp>(op)) {
-    // llvm::outs() << "GetGlobalFixedOp\n";
     lowerGetGlobalFixedOp(new_op);
   } else if (auto new_op = dyn_cast<FixedToFloatOp>(op)) {
-    // llvm::outs() << "FixedToFloatOp\n";
     lowerFixedToFloat(new_op);
   } else if (auto new_op = dyn_cast<FloatToFixedOp>(op)) {
-    // llvm::outs() << "FloatToFixedOp\n";
     lowerFloatToFixed(new_op);
   } else if (auto new_op = dyn_cast<FixedToIntOp>(op)) {
-    // llvm::outs() << "FixedToIntOp\n";
     lowerFixedToInt(new_op);
   } else if (auto new_op = dyn_cast<IntToFixedOp>(op)) {
-    // llvm::outs() << "IntToFixedOp\n";
     lowerIntToFixed(new_op);
   } else if (auto new_op = dyn_cast<FixedToFixedOp>(op)) {
-    // llvm::outs() << "FixedToFixedOp\n";
-    // llvm::outs() << *op.getParentOp() << "\n";
     lowerFixedToFixed(new_op);
-    // debug output
-    // llvm::outs() << *op.getParentOp() << "\n";
   } else if (auto new_op = dyn_cast<scf::IfOp>(op)) {
-    // llvm::outs() << "IfOp\n";
     updateSCFIfOp(new_op);
   } else if (auto new_op = dyn_cast<func::CallOp>(op)) {
     updateCallOp(new_op);
@@ -1258,7 +866,8 @@ void visitOperation(Operation &op) {
 
 void visitBlock(Block &block) {
   SmallVector<Operation *, 10> opToRemove;
-  for (auto &op : block.getOperations()) {
+  for (auto it = block.rbegin(); it != block.rend(); ++it) {
+    Operation &op = *it;
     visitOperation(op);
     if (llvm::isa<AddFixedOp, SubFixedOp, MulFixedOp, DivFixedOp, CmpFixedOp,
                   MinFixedOp, MaxFixedOp, IntToFixedOp, FixedToIntOp,
@@ -1288,25 +897,11 @@ bool applyFixedPointToInteger(ModuleOp &mod) {
   for (func::FuncOp func : mod.getOps<func::FuncOp>()) {
     lowerPrintMemRefOp(func);
     lowerPrintOp(func);
-    markFixedArithOps(func);
-    markFixedCastOps(func);
-    // llvm::outs() << "markFixedCastOps done\n";
-    FunctionType newFuncType = updateFunctionSignature(func);
-    // llvm::outs() << "updateFunctionSignature done\n";
-    updateAffineLoad(func);
-    // llvm::outs() << "updateAffineLoad done\n";
-    updateAlloc(func);
-    // llvm::outs() << "updateAlloc done\n";
-    updateAffineLoad(func);
-    // llvm::outs() << "updateAffineLoad done\n";
+    // lower arith, scf, conversion ops
     visitRegion(func.getBody());
-    // llvm::outs() << "visitRegion done\n";
-    updateAffineLoad(func);
-    // llvm::outs() << "updateAffineLoad done\n";
-    updateReturnOp(func);
-    // llvm::outs() << "updateReturnOp done\n";
-    func.setType(newFuncType);
-    // validate
+    updateFunctionSignature(func);
+    updateAlloc(func);
+    updateAffineLoadStore(func);
     validateLoweredFunc(func);
   }
 


### PR DESCRIPTION
## Description

This PR refactors `fixed-to-integer` pass. I made three major changes:
1. Removing the assumption of top-level function args being 64-bit.
2. Removing the assumption that function arguments are all memref types.
3. Removing the annotation process of fixed-point type info.

Housekeeping 🧹 
- Removed duplicate code in binary op lowering.
- Removed repeated `updateAffineLoad` calls.
- Simplified func type and call op updating functions. 

## New tests

Two new tests from #193 and #194  are added to `test/Transforms/datatype/fixedpoint.mlir`

## Notes for future references

There was an annotation process where each fixed-point operation is tagged with attributes to record its fixed-point type info, such as width, frac, sign. This was necessary because we were converting the operations from top to bottom. For example, if I have:
```mlir
%0 = hcl.add_fixed %arg0, %arg1: !hcl.Fixed<5, 3>
%1 = hcl.add_fixed %0, %arg2: !hcl.Fixed<5, 3>
```
By the time we visit the second operation, the first operation is already lowered to `arith.addi`, and `%0` becomes `i5`, and we   don't know the fixed point type info for `%0` anymore, i.e., converting the defining operation result type "covers" its users.
The annotation process solves this issue by tagging the fixed-point type info as attributes to these operations. 

A better way to do this is to just transform the fixed-point operations in a reversed order in each block. 
```cpp
void visitBlock(Block &block) {
  for (auto it = block.rbegin(); it != block.rend(); ++it) {
    Operation &op = *it;
    visitOperation(op);
  }
}
```
This way, each operation conversion only updates the operation result, i.e. we update user operations first, and the upstream "defining" operations are not affected.

