### PR TITLE
[Fix] Skip functions that do not have a body

### DIFF
--- a/lib/Transforms/LoopTransformations.cpp
+++ b/lib/Transforms/LoopTransformations.cpp
@@ -3534,6 +3534,9 @@ void applyCustomization(
     func::FuncOp &top_func,
     std::map<std::string, hcl::CustomizationOp> &customizationMap,
     SmallVector<Operation *, 10> &opToRemove) {
+  // skip if top_func has no body
+  if (top_func.getBlocks().size() == 0)
+    return;
   auto builder = OpBuilder::atBlockTerminator(&(top_func.getBody().front()));
   for (auto applyOp : top_func.getOps<hcl::ApplyOp>()) {
     auto c = customizationMap[applyOp.getCallee().str()];


### PR DESCRIPTION
This PR fixes a subtle bug in LoopTransformation. Previously we suppose all the functions in an MLIR module have a function body, so we can apply customizations on that. However, some of the MLIR functions may not have a body defined in the module, but have external definitions in C/C++. In that case, we need to skip those functions to avoid possible errors.