### PR TITLE
[Binding] Fix AffineForOp python binding

### DIFF
--- a/include/hcl/Bindings/Python/hcl/dialects/_affine_ops_ext.py
+++ b/include/hcl/Bindings/Python/hcl/dialects/_affine_ops_ext.py
@@ -59,9 +59,9 @@ class AffineForOp:
             attributes["reduction"] = reduction
         if lower_bound == None and upper_bound == None:
             operands = list(iter_args)
-        elif lower_bound != None:
+        elif lower_bound != None and upper_bound == None:
             operands = [lower_bound] + list(iter_args)
-        elif upper_bound != None:
+        elif upper_bound != None and lower_bound == None:
             operands = [upper_bound] + list(iter_args)
         else:
             operands = [lower_bound, upper_bound] + list(iter_args)


### PR DESCRIPTION
This PR resolves [allo/#93](https://github.com/cornell-zhang/allo/issues/93). If both loop bounds are affine expressions, the `AffineForOp` class will only encode one as the variable, due to the incorrect `if` condition.