### PR TITLE
[Backend] Support generating memref.subview + array of FIFOs

### DIFF
--- a/include/hcl/Dialect/Visitor.h
+++ b/include/hcl/Dialect/Visitor.h
@@ -44,7 +44,7 @@ public:
             memref::AllocOp, memref::AllocaOp, memref::LoadOp, memref::StoreOp,
             memref::GetGlobalOp, hcl::GetGlobalFixedOp, memref::GlobalOp,
             memref::DeallocOp, memref::DmaStartOp, memref::DmaWaitOp,
-            memref::ViewOp, memref::SubViewOp, memref::AtomicRMWOp,
+            memref::ViewOp, memref::SubViewOp, memref::ReinterpretCastOp, memref::AtomicRMWOp,
             // Tensor-related statements.
             tensor::ExtractOp, tensor::InsertOp, memref::TensorStoreOp,
             tensor::SplatOp, memref::DimOp, memref::RankOp,
@@ -137,6 +137,7 @@ public:
   HANDLE(memref::AtomicRMWOp);
   HANDLE(memref::ViewOp);
   HANDLE(memref::SubViewOp);
+  HANDLE(memref::ReinterpretCastOp);
 
   // Tensor-related statements.
   HANDLE(tensor::ExtractOp);

--- a/lib/Translation/EmitVivadoHLS.cpp
+++ b/lib/Translation/EmitVivadoHLS.cpp
@@ -127,6 +127,7 @@ public:
   void emitGetGlobal(memref::GetGlobalOp op);
   void emitGetGlobalFixed(hcl::GetGlobalFixedOp op);
   void emitGlobal(memref::GlobalOp op);
+  void emitSubView(memref::SubViewOp op);
 
   /// Tensor-related statement emitters.
   void emitTensorExtract(tensor::ExtractOp op);
@@ -311,6 +312,9 @@ public:
   }
   bool visitOp(memref::GlobalOp op) { return emitter.emitGlobal(op), true; }
   bool visitOp(memref::DeallocOp op) { return true; }
+  bool visitOp(memref::SubViewOp op) {
+    return emitter.emitSubView(op), true;
+  }
 
   /// Tensor-related statements.
   bool visitOp(tensor::ExtractOp op) {
@@ -1199,6 +1203,20 @@ void ModuleEmitter::emitGlobal(memref::GlobalOp op) {
     emitInfoAndNewLine(op);
     os << "\n";
   }
+}
+
+void ModuleEmitter::emitSubView(memref::SubViewOp op) {
+  indent();
+  emitArrayDecl(op.getResult());
+  os << " = ";
+  emitValue(op.getSource());
+  for (auto index : op.getOffsets()) {
+    os << "[";
+    emitValue(index);
+    os << "]";
+  }
+  os << ";";
+  emitInfoAndNewLine(op);
 }
 
 void ModuleEmitter::emitTensorExtract(tensor::ExtractOp op) {

--- a/lib/Translation/EmitVivadoHLS.cpp
+++ b/lib/Translation/EmitVivadoHLS.cpp
@@ -1273,7 +1273,7 @@ void ModuleEmitter::emitGlobal(memref::GlobalOp op) {
 
 void ModuleEmitter::emitSubView(memref::SubViewOp op) {
   indent();
-  emitArrayDecl(op.getResult());
+  emitArrayDecl(op.getResult(), true);
   os << " = ";
   emitValue(op.getSource());
   for (auto index : op.getOffsets()) {


### PR DESCRIPTION
This PR adds codegen support for `memref.subview` and array of FIFOs. To generate array of FIFOs, the array should be annotated with `<"stream:100;SST">`, where `100` is the FIFO depth, `S` means the first dimension is a spatial dimension, and `T` means the last dimension is a temporal dimension, which will be collapsed as `hls::stream`.