### PR TITLE
[Backend] Remove compulsory const type prefix in HLS

### DIFF
--- a/lib/Translation/EmitVivadoHLS.cpp
+++ b/lib/Translation/EmitVivadoHLS.cpp
@@ -1221,7 +1221,6 @@ void ModuleEmitter::emitGlobal(memref::GlobalOp op) {
   fixUnsignedType(op, op->hasAttr("unsigned"));
   auto attr = init_val.value();
   if (auto denseAttr = attr.dyn_cast<DenseElementsAttr>()) {
-    os << "\n";
     indent();
     auto arrayType = op.getType().cast<ShapedType>();
     auto type = arrayType.getElementType();

--- a/lib/Translation/EmitVivadoHLS.cpp
+++ b/lib/Translation/EmitVivadoHLS.cpp
@@ -1225,7 +1225,9 @@ void ModuleEmitter::emitGlobal(memref::GlobalOp op) {
     indent();
     auto arrayType = op.getType().cast<ShapedType>();
     auto type = arrayType.getElementType();
-    os << "const ";
+    if (op->hasAttr("constant")) {
+      os << "const ";
+    }
     os << getTypeName(type);
     os << " " << op.getSymName();
     for (auto &shape : arrayType.getShape())
@@ -1267,7 +1269,6 @@ void ModuleEmitter::emitGlobal(memref::GlobalOp op) {
     }
     os << "};";
     emitInfoAndNewLine(op);
-    os << "\n";
   }
 }
 


### PR DESCRIPTION
As the title reads, this PR removes compulsory "const" generation for global tensors. It will check whether the op has a "const" attribute to determine whether to generate a prefix. Basically, it will cause an error when we have multiple functions, and the constant tensors are passed through some function arguments, where we do not update the function signatures, causing the error.