### PR TITLE
[Conversion][FixedPointToInteger] Fix issue with `updateCallOp`

### DIFF
--- a/lib/Conversion/FixedPointToInteger.cpp
+++ b/lib/Conversion/FixedPointToInteger.cpp
@@ -643,22 +643,9 @@ void updateCallOp(func::CallOp &op) {
   SmallVector<Type, 4> result_types =
       llvm::to_vector<4>(callee_type.getResults());
   llvm::SmallVector<Type, 4> new_result_types;
-  llvm::SmallVector<Type, 4> new_arg_types;
-  for (auto v : llvm::enumerate(result_types)) {
-    Type t = v.value();
-    if (MemRefType memrefType = t.dyn_cast<MemRefType>()) {
-      Type et = memrefType.getElementType();
-      if (et.isa<FixedType, UFixedType>()) {
-        size_t width = et.isa<FixedType>() ? et.cast<FixedType>().getWidth()
-                                           : et.cast<UFixedType>().getWidth();
-        Type newElementType = IntegerType::get(op.getContext(), width);
-        new_result_types.push_back(memrefType.clone(newElementType));
-      } else {
-        new_result_types.push_back(memrefType);
-      }
-    } else { // If result type is not memref, error out
-      op.emitError("updateCallOp: result type is not memref");
-    }
+  for (Type t : result_types) {
+    Type new_type = convertFixedMemRefOrScalarToInt(t, op.getContext());
+    new_result_types.push_back(new_type);
   }
   // set call op result types to new_result_types
   for (auto v : llvm::enumerate(new_result_types)) {


### PR DESCRIPTION
## Description

`updateCallOp` should update the result types of a `func.call` operation if any of the result type is a fixed point type memref or scalar. 

This PR updates the  type update judgement logic, from implementing the function's own to using the shared utility function `convertFixedMemRefOrScalarToInt`. 

## Test added

After this PR, the FixedToInteger pass should be able to pass functions with scalar return types, such as:
```mlir
func.func @callee(%arg0: f32, %arg1: f32) -> f32 attributes {itypes = "__", otypes = "_"} {
    %0 = arith.addf %arg0, %arg1 : f32
    %alloc = memref.alloc() {name = "c"} : memref<1xf32>
    affine.store %0, %alloc[0] {to = "c"} : memref<1xf32>
    %1 = affine.load %alloc[0] {from = "c"} : memref<1xf32>
    %2 = affine.load %alloc[0] {from = "c"} : memref<1xf32>
    return %2 : f32
  }

  func.func @test_scalar_result_func_calls(%arg0: memref<10xf32>, %arg1: memref<10xf32>) -> memref<10xf32> attributes {itypes = "__", otypes = "_"} {
    %c0_i32 = arith.constant 0 : i32
    %0 = arith.sitofp %c0_i32 : i32 to f32
    %alloc = memref.alloc() {name = "C"} : memref<10xf32>
    linalg.fill ins(%0 : f32) outs(%alloc : memref<10xf32>)
    affine.for %arg2 = 0 to 10 {
      %1 = affine.load %arg0[%arg2] {from = "A"} : memref<10xf32>
      %2 = affine.load %arg1[%arg2] {from = "B"} : memref<10xf32>
      %3 = func.call @callee(%1, %2) : (f32, f32) -> f32
      affine.store %3, %alloc[%arg2] {to = "C"} : memref<10xf32>
    } {loop_name = "i", op_name = "S_i_0"}
    return %alloc : memref<10xf32>
  }
```

This test is added to `test/Transforms/datatype/fixedpoint.mlir`